### PR TITLE
feat(tools): add soroban multi-network config loader, tests, CLI verifier, and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+## Example environment variables for Soroban configuration
+## Safe for publishing: do NOT add real secrets here.
+
+# Choose which profile to use from `soroban.toml`. Set to one of the profile
+# names (e.g. `testnet`, `mainnet`, `sandbox`). If unset, the loader will
+# prefer a `testnet` profile in `soroban.toml` or fail if ambiguous.
+SOROBAN_NETWORK=
+
+# Optional: Fully override the RPC URL. When set, this value takes precedence
+# over the `rpc_url` defined in the chosen profile inside `soroban.toml`.
+SOROBAN_RPC_URL=
+
+# Optional: Fully override the network passphrase. When set, this value takes
+# precedence over the `network_passphrase` defined in the chosen profile.
+SOROBAN_NETWORK_PASSPHRASE=
+
+# Behavior summary:
+# - If `SOROBAN_NETWORK` is set it selects a profile (or a well-known network
+#   name like `testnet`/`mainnet`/`sandbox`).
+# - `SOROBAN_RPC_URL` and `SOROBAN_NETWORK_PASSPHRASE` override the values from
+#   the selected profile when present.
+# - If neither environment variables nor an unambiguous profile exists, the
+#   loader fails with a clear message.

--- a/README.md
+++ b/README.md
@@ -203,3 +203,40 @@ Open a Pull Request from your fork back to the main branch.
 
 # 📜 License
 MIT License — free to use, modify, and distribute.
+
+## Soroban Configuration (networks)
+
+This workspace includes a deterministic, strongly-typed Soroban network configuration system.
+
+Add a network (example CLI stub):
+
+```bash
+soroban config network add <name> \
+   --rpc-url <url> \
+   --network-passphrase "<passphrase>"
+```
+
+List networks (profiles in `soroban.toml`):
+
+```bash
+soroban config network ls
+```
+
+Select a network (this sets the active profile name; loader reads `SOROBAN_NETWORK`):
+
+```bash
+soroban config network use <name>
+```
+
+Environment variable override behavior
+
+- `SOROBAN_NETWORK` selects a profile (e.g. `testnet`, `mainnet`, `sandbox`).
+- `SOROBAN_RPC_URL` and `SOROBAN_NETWORK_PASSPHRASE` override profile values when set.
+
+Verify the resolved network with the included CLI tool:
+
+```bash
+cargo run -p stellaraid-tools -- network
+```
+
+See `.env.example` for a safe example of environment variables you can copy to `.env`.

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -12,3 +12,10 @@ soroban-sdk = { workspace = true }
 clap = { version = "4.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 anyhow = "1.0"
+dotenvy = "0.15"
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.7"
+thiserror = "1.0"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+mod config;
+use config::Config;
+
 #[derive(Parser)]
 #[command(name = "stellaraid-cli")]
 #[command(about = "StellarAid CLI tools for contract deployment and management")]
@@ -11,16 +14,20 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Deploy a contract (placeholder)
     Deploy {
         #[arg(short, long)]
         network: String,
         #[arg(short, long)]
         contract_id: Option<String>,
     },
+    /// Configuration utilities
     Config {
         #[command(subcommand)]
         action: ConfigAction,
     },
+    /// Print resolved network configuration
+    Network,
 }
 
 #[derive(Subcommand)]
@@ -41,17 +48,25 @@ fn main() -> Result<()> {
             if let Some(id) = contract_id {
                 println!("Using contract ID: {}", id);
             }
-            // TODO: Implement deployment logic
         }
-        Commands::Config { action } => {
-            match action {
-                ConfigAction::Check => {
-                    println!("Checking configuration...");
-                    // TODO: Implement config check
+        Commands::Config { action } => match action {
+            ConfigAction::Check => {
+                println!("Checking configuration...");
+            }
+            ConfigAction::Init => {
+                println!("Initializing configuration...");
+            }
+        },
+        Commands::Network => {
+            match Config::load(None) {
+                Ok(cfg) => {
+                    println!("Active network: {}", cfg.network);
+                    println!("RPC URL: {}", cfg.rpc_url);
+                    println!("Passphrase: {}", cfg.network_passphrase);
                 }
-                ConfigAction::Init => {
-                    println!("Initializing configuration...");
-                    // TODO: Implement config initialization
+                Err(e) => {
+                    eprintln!("Failed to load config: {}", e);
+                    std::process::exit(2);
                 }
             }
         }

--- a/soroban.toml
+++ b/soroban.toml
@@ -1,0 +1,14 @@
+[profile.testnet]
+network = "testnet"
+rpc_url = "https://soroban-testnet.stellar.org"
+network_passphrase = "Test SDF Network ; September 2015"
+
+[profile.mainnet]
+network = "mainnet"
+rpc_url = "https://mainnet.sorobanrpc.com"
+network_passphrase = "Public Global Stellar Network ; September 2015"
+
+[profile.sandbox]
+network = "sandbox"
+rpc_url = "http://localhost:8000"
+network_passphrase = "Standalone Network ; February 2017"


### PR DESCRIPTION
Closes:  #4 
## Summary
Adds a deterministic, strongly-typed Soroban network configuration system that resolves the
active network from environment variables and `soroban.toml` profiles, with clear error
handling, unit tests, and a small CLI verifier.

## Files changed
- Added: `soroban.toml`
- Added: `.env.example`
- Added: `crates/tools/src/config.rs` (typed loader, errors, and tests)
- Updated: `crates/tools/Cargo.toml` (deps)
- Updated: `crates/tools/src/main.rs` (CLI `network` command)
- Updated: `README.md` (docs snippet)

## What it does
- Implements `Config::load()` with resolution order:
  1. Environment variables: `SOROBAN_NETWORK`, `SOROBAN_RPC_URL`, `SOROBAN_NETWORK_PASSPHRASE`
  2. Profile selected in `soroban.toml` (`testnet`, `mainnet`, `sandbox`, or custom)
  3. Fail with typed `ConfigError` when ambiguous or missing required values
- Provides `Network` enum and a strongly-typed `Config` struct for use by deployment
  scripts and tests.
- CLI verifier: `cargo run -p stellaraid-tools -- network` prints:
  - Active network: <name>
  - RPC URL: <url>
  - Passphrase: <passphrase>

## Tests & verification
Included unit tests under `crates/tools`:
- `loads_profile_by_name` — profile resolution (testnet)
- `env_overrides_profile_values` — env vars override profile
- `missing_required_values_returns_error` — fails with typed error if required values missing
- `loads_sandbox_profile` — sandbox profile

Run locally:
```bash
cargo test -p stellaraid-tools
cargo run -p stellaraid-tools -- network
```

## Rationale
- Keeps this crate focused on resolving and exposing effective configuration; relies on the
  official Soroban CLI for editing/managing `soroban.toml`.
- Uses `dotenvy`, `serde` + `toml`, and `thiserror` for robust parsing and structured errors.
- Tests isolate environment loading to avoid flakiness and ensure determinism.

## Notes for reviewer
- The loader searches upward from the current working directory for `soroban.toml`.
  If a `.env` file sits adjacent to the chosen `soroban.toml`, it will be loaded (allowing
  project-local `.env` overrides).
- `.env.example` contains no secrets and documents override behavior.
- No configuration editing commands were added (per design decision).

## Commit
- 27335be — feat(tools): add soroban multi-network config loader, tests, CLI verifier, and docs

## Next steps
To push and open a PR:
```bash
git push -u origin feat/Network
# then open a PR on GitHub with this description
```

