### PR TITLE
feat: resolve issues #132, #139, #140, #141

### DIFF
--- a/crates/tools/src/campaign_totals.rs
+++ b/crates/tools/src/campaign_totals.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
-/// In-memory store for per-campaign donation totals.
+/// In-memory store for per-campaign donation totals, grouped by asset.
 ///
-/// In production replace the inner map with a database connection.
+/// Issue #141 – Track Total Volume by Asset
 #[derive(Default)]
 pub struct CampaignTotals {
-    totals: HashMap<u64, i128>,
+    /// (campaign_id, asset) → total
+    asset_totals: HashMap<(u64, String), i128>,
 }
 
 impl CampaignTotals {
@@ -13,16 +14,34 @@ impl CampaignTotals {
         Self::default()
     }
 
-    /// Adds `amount` to the running total for `campaign_id` and returns the new total.
-    pub fn increment(&mut self, campaign_id: u64, amount: i128) -> i128 {
-        let entry = self.totals.entry(campaign_id).or_insert(0);
+    /// Adds `amount` to the running total for `campaign_id` + `asset` and returns the new total.
+    pub fn increment(&mut self, campaign_id: u64, asset: &str, amount: i128) -> i128 {
+        let entry = self.asset_totals.entry((campaign_id, asset.to_string())).or_insert(0);
         *entry += amount;
         *entry
     }
 
-    /// Returns the current total for `campaign_id`, or 0 if none recorded yet.
-    pub fn get(&self, campaign_id: u64) -> i128 {
-        *self.totals.get(&campaign_id).unwrap_or(&0)
+    /// Returns the total for a specific `campaign_id` + `asset`, or 0 if none recorded.
+    pub fn get(&self, campaign_id: u64, asset: &str) -> i128 {
+        *self.asset_totals.get(&(campaign_id, asset.to_string())).unwrap_or(&0)
+    }
+
+    /// Returns all asset totals for a campaign as a map of asset → total.
+    pub fn get_all_assets(&self, campaign_id: u64) -> HashMap<String, i128> {
+        self.asset_totals
+            .iter()
+            .filter(|((cid, _), _)| *cid == campaign_id)
+            .map(|((_, asset), total)| (asset.clone(), *total))
+            .collect()
+    }
+
+    /// Returns the aggregate total across all assets for a campaign.
+    pub fn get_campaign_total(&self, campaign_id: u64) -> i128 {
+        self.asset_totals
+            .iter()
+            .filter(|((cid, _), _)| *cid == campaign_id)
+            .map(|(_, total)| total)
+            .sum()
     }
 }
 
@@ -33,23 +52,50 @@ mod tests {
     #[test]
     fn starts_at_zero() {
         let totals = CampaignTotals::new();
-        assert_eq!(totals.get(1), 0);
+        assert_eq!(totals.get(1, "XLM"), 0);
     }
 
     #[test]
-    fn increments_correctly() {
+    fn increments_per_asset() {
         let mut totals = CampaignTotals::new();
-        totals.increment(1, 500);
-        totals.increment(1, 300);
-        assert_eq!(totals.get(1), 800);
+        totals.increment(1, "XLM", 500);
+        totals.increment(1, "XLM", 300);
+        assert_eq!(totals.get(1, "XLM"), 800);
+    }
+
+    #[test]
+    fn different_assets_are_independent() {
+        let mut totals = CampaignTotals::new();
+        totals.increment(1, "XLM", 100);
+        totals.increment(1, "USDC", 200);
+        assert_eq!(totals.get(1, "XLM"), 100);
+        assert_eq!(totals.get(1, "USDC"), 200);
     }
 
     #[test]
     fn different_campaigns_are_independent() {
         let mut totals = CampaignTotals::new();
-        totals.increment(1, 100);
-        totals.increment(2, 200);
-        assert_eq!(totals.get(1), 100);
-        assert_eq!(totals.get(2), 200);
+        totals.increment(1, "XLM", 100);
+        totals.increment(2, "XLM", 200);
+        assert_eq!(totals.get(1, "XLM"), 100);
+        assert_eq!(totals.get(2, "XLM"), 200);
+    }
+
+    #[test]
+    fn get_all_assets_returns_correct_map() {
+        let mut totals = CampaignTotals::new();
+        totals.increment(1, "XLM", 500);
+        totals.increment(1, "USDC", 300);
+        let map = totals.get_all_assets(1);
+        assert_eq!(map.get("XLM"), Some(&500));
+        assert_eq!(map.get("USDC"), Some(&300));
+    }
+
+    #[test]
+    fn campaign_total_aggregates_all_assets() {
+        let mut totals = CampaignTotals::new();
+        totals.increment(1, "XLM", 500);
+        totals.increment(1, "USDC", 300);
+        assert_eq!(totals.get_campaign_total(1), 800);
     }
 }

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -6,3 +6,6 @@ pub mod asset_issuing;
 pub mod keypair_manager;
 pub mod signing_request;
 pub mod response_handler;
+pub mod campaign_totals;
+pub mod withdrawal_audit;
+pub mod withdrawal_limits;

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -29,6 +29,13 @@ use response_handler::{ResponseHandler, SignedTransaction};
 mod worker_logger;
 mod polling_scheduler;
 
+// Issue #141 – per-asset campaign totals
+mod campaign_totals;
+// Issue #140 – withdrawal audit log
+mod withdrawal_audit;
+// Issue #139 – withdrawal limits
+mod withdrawal_limits;
+
 fn main() -> Result<()> {
     dotenv::dotenv().ok();
 

--- a/crates/tools/src/signing_request.rs
+++ b/crates/tools/src/signing_request.rs
@@ -1,6 +1,8 @@
 use anyhow::{Result, Context, anyhow};
+use anyhow::{Result, Context, anyhow};
 use serde::{Serialize, Deserialize};
 use serde_json::json;
+use sha2::{Digest, Sha256};
 use std::env;
 
 /// Represents a signing request for a Stellar transaction
@@ -183,6 +185,48 @@ impl SigningRequest {
     }
 }
 
+/// Issue #132 – A transaction that has been signed server-side.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerSignedTransaction {
+    pub request_id: String,
+    pub transaction_xdr: String,
+    /// Hex-encoded SHA-256(secret_key || transaction_xdr) used as the server signature.
+    pub signature: String,
+    pub signed_at: i64,
+}
+
+impl SigningRequest {
+    /// Issue #132 – Sign this transaction server-side using the provided secret key.
+    ///
+    /// Produces a deterministic signature: SHA-256(secret_key_bytes || xdr_bytes),
+    /// which proves the server holding the secret key authorised this XDR.
+    pub fn sign_server_side(&self, secret_key: &str) -> Result<ServerSignedTransaction> {
+        if secret_key.is_empty() {
+            return Err(anyhow!("Secret key must not be empty"));
+        }
+        crate::key_manager::KeyManager::validate_secret_key(secret_key)?;
+
+        let mut hasher = Sha256::new();
+        hasher.update(secret_key.as_bytes());
+        hasher.update(self.transaction_xdr.as_bytes());
+        let signature = hex::encode(hasher.finalize());
+
+        Ok(ServerSignedTransaction {
+            request_id: self.id.clone(),
+            transaction_xdr: self.transaction_xdr.clone(),
+            signature,
+            signed_at: chrono::Local::now().timestamp(),
+        })
+    }
+
+    /// Issue #132 – Sign using the secret key stored in the SOROBAN_SECRET_KEY env var.
+    pub fn sign_from_env(&self) -> Result<ServerSignedTransaction> {
+        let secret_key = env::var("SOROBAN_SECRET_KEY")
+            .context("SOROBAN_SECRET_KEY not set in environment")?;
+        self.sign_server_side(&secret_key)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -228,5 +272,63 @@ mod tests {
         let json = req.to_json().unwrap();
         let restored = SigningRequest::from_json(&json).unwrap();
         assert_eq!(restored.id, req.id);
+    }
+
+    #[test]
+    fn test_sign_server_side_produces_signature() {
+        let req = SigningRequest {
+            id: "req_123".to_string(),
+            network: "testnet".to_string(),
+            transaction_xdr: "AAAAAA==test_xdr".to_string(),
+            description: "Test".to_string(),
+            created_at: 0,
+        };
+        let secret = "SBZXVMIRWXL5VZVKXWV2FGKYTQ5VV5VRNJYQVZKYWW3XYVYP3IXGKDU";
+        let signed = req.sign_server_side(secret).unwrap();
+        assert_eq!(signed.request_id, "req_123");
+        assert!(!signed.signature.is_empty());
+        assert_eq!(signed.transaction_xdr, req.transaction_xdr);
+    }
+
+    #[test]
+    fn test_sign_server_side_is_deterministic() {
+        let req = SigningRequest {
+            id: "req_123".to_string(),
+            network: "testnet".to_string(),
+            transaction_xdr: "AAAAAA==test_xdr".to_string(),
+            description: "Test".to_string(),
+            created_at: 0,
+        };
+        let secret = "SBZXVMIRWXL5VZVKXWV2FGKYTQ5VV5VRNJYQVZKYWW3XYVYP3IXGKDU";
+        let sig1 = req.sign_server_side(secret).unwrap().signature;
+        let sig2 = req.sign_server_side(secret).unwrap().signature;
+        assert_eq!(sig1, sig2);
+    }
+
+    #[test]
+    fn test_sign_server_side_different_keys_differ() {
+        let req = SigningRequest {
+            id: "req_123".to_string(),
+            network: "testnet".to_string(),
+            transaction_xdr: "AAAAAA==test_xdr".to_string(),
+            description: "Test".to_string(),
+            created_at: 0,
+        };
+        let sig1 = req.sign_server_side("SBZXVMIRWXL5VZVKXWV2FGKYTQ5VV5VRNJYQVZKYWW3XYVYP3IXGKDU").unwrap().signature;
+        let sig2 = req.sign_server_side("SCZANGBA5QDPSBM5QOTSXSI7JKEFYABMUQRPTGMWNJKFA5ENDNSQSTE").unwrap().signature;
+        assert_ne!(sig1, sig2);
+    }
+
+    #[test]
+    fn test_sign_server_side_rejects_invalid_key() {
+        let req = SigningRequest {
+            id: "req_123".to_string(),
+            network: "testnet".to_string(),
+            transaction_xdr: "AAAAAA==".to_string(),
+            description: "Test".to_string(),
+            created_at: 0,
+        };
+        assert!(req.sign_server_side("not_a_valid_key").is_err());
+        assert!(req.sign_server_side("").is_err());
     }
 }

--- a/crates/tools/src/withdrawal_audit.rs
+++ b/crates/tools/src/withdrawal_audit.rs
@@ -1,0 +1,124 @@
+use chrono::Utc;
+use std::collections::HashMap;
+
+/// Issue #140 – Audit Withdrawal Logs
+/// Records every withdrawal action with a complete audit trail.
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum WithdrawalAction {
+    Requested,
+    Approved,
+    Rejected,
+    Submitted,
+}
+
+impl std::fmt::Display for WithdrawalAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WithdrawalAction::Requested => write!(f, "REQUESTED"),
+            WithdrawalAction::Approved => write!(f, "APPROVED"),
+            WithdrawalAction::Rejected => write!(f, "REJECTED"),
+            WithdrawalAction::Submitted => write!(f, "SUBMITTED"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WithdrawalLogEntry {
+    pub campaign_id: u64,
+    pub action: WithdrawalAction,
+    pub actor: String,
+    pub amount: i128,
+    pub timestamp: i64,
+    pub note: Option<String>,
+}
+
+/// In-memory audit log for withdrawal actions.
+#[derive(Default)]
+pub struct WithdrawalAuditLog {
+    entries: Vec<WithdrawalLogEntry>,
+}
+
+impl WithdrawalAuditLog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Log a withdrawal action.
+    pub fn log(&mut self, campaign_id: u64, action: WithdrawalAction, actor: &str, amount: i128, note: Option<String>) {
+        self.entries.push(WithdrawalLogEntry {
+            campaign_id,
+            action,
+            actor: actor.to_string(),
+            amount,
+            timestamp: Utc::now().timestamp(),
+            note,
+        });
+    }
+
+    /// Returns all log entries for a campaign.
+    pub fn get_by_campaign(&self, campaign_id: u64) -> Vec<&WithdrawalLogEntry> {
+        self.entries.iter().filter(|e| e.campaign_id == campaign_id).collect()
+    }
+
+    /// Returns all entries in the log.
+    pub fn all(&self) -> &[WithdrawalLogEntry] {
+        &self.entries
+    }
+
+    /// Returns a summary: count of each action type per campaign.
+    pub fn summary(&self) -> HashMap<u64, HashMap<String, usize>> {
+        let mut result: HashMap<u64, HashMap<String, usize>> = HashMap::new();
+        for entry in &self.entries {
+            result
+                .entry(entry.campaign_id)
+                .or_default()
+                .entry(entry.action.to_string())
+                .and_modify(|c| *c += 1)
+                .or_insert(1);
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logs_and_retrieves_entries() {
+        let mut log = WithdrawalAuditLog::new();
+        log.log(1, WithdrawalAction::Requested, "creator_A", 500, None);
+        log.log(1, WithdrawalAction::Approved, "admin", 500, Some("looks good".to_string()));
+
+        let entries = log.get_by_campaign(1);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].action, WithdrawalAction::Requested);
+        assert_eq!(entries[1].action, WithdrawalAction::Approved);
+        assert_eq!(entries[1].note.as_deref(), Some("looks good"));
+    }
+
+    #[test]
+    fn different_campaigns_are_isolated() {
+        let mut log = WithdrawalAuditLog::new();
+        log.log(1, WithdrawalAction::Requested, "creator_A", 100, None);
+        log.log(2, WithdrawalAction::Requested, "creator_B", 200, None);
+
+        assert_eq!(log.get_by_campaign(1).len(), 1);
+        assert_eq!(log.get_by_campaign(2).len(), 1);
+    }
+
+    #[test]
+    fn summary_counts_actions() {
+        let mut log = WithdrawalAuditLog::new();
+        log.log(1, WithdrawalAction::Requested, "creator_A", 100, None);
+        log.log(1, WithdrawalAction::Approved, "admin", 100, None);
+        log.log(1, WithdrawalAction::Submitted, "admin", 100, None);
+
+        let summary = log.summary();
+        let campaign_summary = &summary[&1];
+        assert_eq!(campaign_summary["REQUESTED"], 1);
+        assert_eq!(campaign_summary["APPROVED"], 1);
+        assert_eq!(campaign_summary["SUBMITTED"], 1);
+    }
+}

--- a/crates/tools/src/withdrawal_limits.rs
+++ b/crates/tools/src/withdrawal_limits.rs
@@ -1,0 +1,105 @@
+use anyhow::{anyhow, Result};
+
+/// Issue #139 – Add Withdrawal Limits
+/// Defines per-campaign and global withdrawal rules and enforces them.
+
+/// Configurable withdrawal limits for a campaign.
+#[derive(Debug, Clone)]
+pub struct WithdrawalLimits {
+    /// Maximum single withdrawal amount (in stroops).
+    pub max_per_withdrawal: i128,
+    /// Minimum single withdrawal amount (in stroops).
+    pub min_per_withdrawal: i128,
+    /// Maximum total withdrawn across all withdrawals for the campaign.
+    pub max_total: Option<i128>,
+}
+
+impl Default for WithdrawalLimits {
+    fn default() -> Self {
+        Self {
+            min_per_withdrawal: 100,          // 100 stroops minimum
+            max_per_withdrawal: 10_000_000_000, // 1000 XLM maximum per withdrawal
+            max_total: None,                  // no global cap by default
+        }
+    }
+}
+
+impl WithdrawalLimits {
+    pub fn new(min: i128, max: i128, max_total: Option<i128>) -> Result<Self> {
+        if min <= 0 {
+            return Err(anyhow!("Minimum withdrawal must be positive"));
+        }
+        if max < min {
+            return Err(anyhow!("Maximum must be >= minimum"));
+        }
+        Ok(Self { min_per_withdrawal: min, max_per_withdrawal: max, max_total })
+    }
+
+    /// Validates a proposed withdrawal amount against the limits.
+    /// `already_withdrawn` is the cumulative amount already withdrawn for this campaign.
+    pub fn validate(&self, amount: i128, already_withdrawn: i128) -> Result<()> {
+        if amount < self.min_per_withdrawal {
+            return Err(anyhow!(
+                "Withdrawal amount {} is below the minimum of {}",
+                amount, self.min_per_withdrawal
+            ));
+        }
+        if amount > self.max_per_withdrawal {
+            return Err(anyhow!(
+                "Withdrawal amount {} exceeds the maximum of {}",
+                amount, self.max_per_withdrawal
+            ));
+        }
+        if let Some(cap) = self.max_total {
+            if already_withdrawn + amount > cap {
+                return Err(anyhow!(
+                    "Total withdrawn {} would exceed the campaign cap of {}",
+                    already_withdrawn + amount, cap
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_limits_accept_normal_amount() {
+        let limits = WithdrawalLimits::default();
+        assert!(limits.validate(1_000_000, 0).is_ok());
+    }
+
+    #[test]
+    fn rejects_below_minimum() {
+        let limits = WithdrawalLimits::default();
+        assert!(limits.validate(10, 0).is_err());
+    }
+
+    #[test]
+    fn rejects_above_maximum() {
+        let limits = WithdrawalLimits::default();
+        assert!(limits.validate(20_000_000_000, 0).is_err());
+    }
+
+    #[test]
+    fn rejects_when_total_cap_exceeded() {
+        let limits = WithdrawalLimits::new(100, 5_000_000, Some(8_000_000)).unwrap();
+        // already withdrawn 6_000_000, trying to withdraw 3_000_000 → total 9_000_000 > 8_000_000
+        assert!(limits.validate(3_000_000, 6_000_000).is_err());
+    }
+
+    #[test]
+    fn accepts_when_within_total_cap() {
+        let limits = WithdrawalLimits::new(100, 5_000_000, Some(8_000_000)).unwrap();
+        assert!(limits.validate(2_000_000, 5_000_000).is_ok());
+    }
+
+    #[test]
+    fn constructor_rejects_invalid_range() {
+        assert!(WithdrawalLimits::new(1000, 500, None).is_err());
+        assert!(WithdrawalLimits::new(0, 500, None).is_err());
+    }
+}


### PR DESCRIPTION
Closes #132, 
Closes #139, 
Closes #140, 
Closes #141

- **#141** Per-asset volume tracking in `CampaignTotals`
- **#140** `WithdrawalAuditLog` — logs all withdrawal actions with audit trail
- **#139** `WithdrawalLimits` — enforces min/max per-withdrawal and total cap
- **#132** Server-side transaction signing via secret key in `SigningRequest`