### PR TITLE
feat: campaign storage schema, data structs, and CI workflow fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
 
       - run: cargo fmt --all --check
 
-      - run: cargo clippy --all-targets --target x86_64-unknown-linux-gnu -- -D warnings
+      - run: cargo clippy --workspace --all-targets --target x86_64-unknown-linux-gnu -- -D warnings
 
-      - run: cargo test --all --target x86_64-unknown-linux-gnu
+      - run: cargo test --workspace --target x86_64-unknown-linux-gnu
 
       - name: WASM build
-        run: cargo build --target wasm32v1-none --release --all
+        run: cargo build --target wasm32v1-none --release --workspace
 
       - name: Report contract sizes
         run: |

--- a/campaign/src/lib.rs
+++ b/campaign/src/lib.rs
@@ -1,4 +1,8 @@
 #![no_std]
+
+pub mod storage;
+pub mod types;
+
 use soroban_sdk::{contract, contractimpl, Env};
 
 #[contract]

--- a/campaign/src/storage.rs
+++ b/campaign/src/storage.rs
@@ -1,0 +1,64 @@
+use soroban_sdk::{Address, Env};
+
+use crate::types::{CampaignData, DataKey, DonorRecord, MilestoneData};
+
+// ── Persistent storage helpers ────────────────────────────────────────────────
+
+pub fn set_campaign(env: &Env, data: &CampaignData) {
+    env.storage().persistent().set(&DataKey::CampaignData, data);
+}
+
+pub fn get_campaign(env: &Env) -> Option<CampaignData> {
+    env.storage().persistent().get(&DataKey::CampaignData)
+}
+
+pub fn set_milestone(env: &Env, index: u32, data: &MilestoneData) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::MilestoneData(index), data);
+}
+
+pub fn get_milestone(env: &Env, index: u32) -> Option<MilestoneData> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::MilestoneData(index))
+}
+
+pub fn set_donor(env: &Env, donor: &Address, record: &DonorRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::DonorData(donor.clone()), record);
+}
+
+pub fn get_donor(env: &Env, donor: &Address) -> Option<DonorRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DonorData(donor.clone()))
+}
+
+pub fn get_total_raised(env: &Env) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TotalRaised)
+        .unwrap_or(0)
+}
+
+pub fn set_total_raised(env: &Env, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::TotalRaised, &amount);
+}
+
+// ── Temporary storage helpers ─────────────────────────────────────────────────
+
+pub fn get_contract_status(env: &Env) -> Option<u32> {
+    env.storage()
+        .temporary()
+        .get(&DataKey::ContractStatus)
+}
+
+pub fn set_contract_status(env: &Env, status: u32) {
+    env.storage()
+        .temporary()
+        .set(&DataKey::ContractStatus, &status);
+}

--- a/campaign/src/types.rs
+++ b/campaign/src/types.rs
@@ -1,0 +1,87 @@
+use soroban_sdk::{contracttype, Address, BytesN, Vec};
+
+// ── Supporting enums ─────────────────────────────────────────────────────────
+
+/// Issue #167 – campaign lifecycle status
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CampaignStatus {
+    Active,
+    Successful,
+    Failed,
+    Cancelled,
+}
+
+/// Issue #168 – milestone release status
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MilestoneStatus {
+    Pending,
+    Released,
+    Cancelled,
+}
+
+/// Accepted asset descriptor (native XLM or a Stellar asset)
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AssetInfo {
+    Native,
+    Stellar(Address),
+}
+
+// ── Issue #166 – storage key enum ────────────────────────────────────────────
+
+/// All persistent storage keys used by the campaign contract.
+/// Implements `contracttype` so Soroban can serialise it via XDR / `IntoVal`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    CampaignData,
+    MilestoneData(u32),
+    DonorData(Address),
+    TotalRaised,
+    ContractStatus,
+}
+
+// ── Issue #167 – CampaignData struct ─────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CampaignData {
+    pub creator: Address,
+    pub goal_amount: i128,
+    pub raised_amount: i128,
+    pub end_time: u64,
+    pub status: CampaignStatus,
+    pub accepted_assets: Vec<AssetInfo>,
+    pub milestone_count: u32,
+}
+
+// ── Issue #168 – MilestoneData struct ────────────────────────────────────────
+
+/// Max 5 milestones enforced at the contract call site.
+pub const MAX_MILESTONES: u32 = 5;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MilestoneData {
+    pub index: u32,
+    pub target_amount: i128,
+    pub description_hash: BytesN<32>,
+    pub status: MilestoneStatus,
+    pub released_at: Option<u64>,
+    pub release_tx: Option<BytesN<32>>,
+}
+
+// ── Issue #169 – DonorRecord struct ──────────────────────────────────────────
+
+/// Stored under `DataKey::DonorData(donor_address)`.
+/// Aggregated per-donor across multiple donations.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DonorRecord {
+    pub donor: Address,
+    pub total_donated: i128,
+    pub asset: AssetInfo,
+    pub last_donation_time: u64,
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown", "wasm32v1-none"]
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Implements issues #166, #167, #168, #169 and fixes CI workflow bugs.

### Changes

**campaign/src/types.rs** (new)
- `DataKey` enum: `CampaignData`, `MilestoneData(u32)`, `DonorData(Address)`, `TotalRaised`, `ContractStatus` — implements `contracttype` for Soroban XDR serialisation
- `CampaignData` struct: `creator`, `goal_amount`, `raised_amount`, `end_time`, `status`, `accepted_assets`, `milestone_count`
- `MilestoneData` struct: `index`, `target_amount`, `description_hash: BytesN<32>`, `status`, `released_at: Option<u64>`, `release_tx: Option<BytesN<32>>`; `MAX_MILESTONES = 5`
- `DonorRecord` struct: `donor`, `total_donated`, `asset`, `last_donation_time` — stored under `DataKey::DonorData(donor_address)`
- Supporting enums: `CampaignStatus`, `MilestoneStatus`, `AssetInfo`

**campaign/src/storage.rs** (new)
- Persistent storage helpers for `CampaignData`, `MilestoneData`, `DonorRecord`, `TotalRaised`
- Temporary storage helpers for `ContractStatus`

**campaign/src/lib.rs**
- Expose `pub mod types` and `pub mod storage`

**CI workflow fixes**
- Replace deprecated `--all` flag with `--workspace` in clippy, test, and WASM build steps
- Add `wasm32v1-none` to `rust-toolchain.toml` targets to match CI configuration

## Closes

Closes #166
Closes #167
Closes #168
Closes #169