### PR TITLE
feat(campaign): add VERSION constant and version() query function

### DIFF
--- a/campaign/src/lib.rs
+++ b/campaign/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, Env};
 
+pub const VERSION: u32 = 1;
+
 #[contract]
 pub struct CampaignContract;
 
@@ -8,5 +10,9 @@ pub struct CampaignContract;
 impl CampaignContract {
     pub fn hello(env: Env) -> soroban_sdk::Symbol {
         soroban_sdk::Symbol::new(&env, "campaign")
+    }
+
+    pub fn version() -> u32 {
+        VERSION
     }
 }


### PR DESCRIPTION
## Summary

Adds contract versioning to `campaign/src/lib.rs`:

- `pub const VERSION: u32 = 1` — module-level version constant
- `pub fn version() -> u32` — queryable public function that returns the constant

The version should be bumped on any breaking contract change per semantic versioning policy.

## Related

closes #163
