### PR TITLE
feat(common): add shared types to common crate

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,9 +1,35 @@
 #![no_std]
-use soroban_sdk::contracterror;
+use soroban_sdk::{contracttype, contracterror};
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum CampaignStatus {
+    Draft,
+    Active,
+    Completed,
+    Cancelled,
+}
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum MilestoneStatus {
+    Pending,
+    Completed,
+    Failed,
+}
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct AssetInfo {
+    pub code: u32,
+    pub issuer: u32,
+}
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum Error {
+pub enum ErrorCode {
     NotInitialized = 1,
     AlreadyInitialized = 2,
+    Unauthorized = 3,
+    InvalidAmount = 4,
 }


### PR DESCRIPTION
## Summary

Extends `common/src/lib.rs` with the shared types needed across all contracts:

- `CampaignStatus` — `Draft`, `Active`, `Completed`, `Cancelled`
- `MilestoneStatus` — `Pending`, `Completed`, `Failed`
- `AssetInfo` — struct with `code: u32` and `issuer: u32`
- `ErrorCode` — `NotInitialized`, `AlreadyInitialized`, `Unauthorized`, `InvalidAmount`

All types use `#[contracttype]` / `#[contracterror]` for on-chain serialization compatibility.

## Related

closes #162
