### PR TITLE
Feat/input

### DIFF
--- a/campaign/src/lib.rs
+++ b/campaign/src/lib.rs
@@ -3,14 +3,124 @@
 pub mod storage;
 pub mod types;
 
-use soroban_sdk::{contract, contractimpl, Env};
+use soroban_sdk::{contract, contractimpl, Env, Vec};
+use types::{AssetInfo, CampaignData, CampaignStatus, Error, MilestoneData};
+use storage::{get_campaign, set_campaign, set_milestone};
 
 #[contract]
 pub struct CampaignContract;
 
 #[contractimpl]
 impl CampaignContract {
+    /// Initialize a new campaign with strict validation on all inputs.
+    ///
+    /// # Panics
+    /// - `Error::InvalidGoalAmount` if goal_amount <= 0
+    /// - `Error::InvalidEndTime` if end_time <= current ledger timestamp
+    /// - `Error::InvalidAssets` if accepted_assets is empty
+    /// - `Error::InvalidMilestones` if milestones are not sorted ascending by target_amount
+    /// - `Error::MilestoneMismatch` if last milestone.target_amount != goal_amount
+    pub fn initialize(
+        env: Env,
+        creator: soroban_sdk::Address,
+        goal_amount: i128,
+        end_time: u64,
+        accepted_assets: Vec<AssetInfo>,
+        milestones: Vec<MilestoneData>,
+    ) -> Result<(), Error> {
+        // Validation 1: goal_amount > 0
+        if goal_amount <= 0 {
+            panic_with_error(&env, Error::InvalidGoalAmount);
+        }
+
+        // Validation 2: end_time > current ledger timestamp
+        let current_timestamp = env.ledger().timestamp();
+        if end_time <= current_timestamp {
+            panic_with_error(&env, Error::InvalidEndTime);
+        }
+
+        // Validation 3: accepted_assets non-empty
+        if accepted_assets.is_empty() {
+            panic_with_error(&env, Error::InvalidAssets);
+        }
+
+        // Validation 4 & 5: milestones sorted ascending and last == goal_amount
+        if !milestones.is_empty() {
+            validate_milestones(&env, &milestones, goal_amount)?;
+        }
+
+        // All validations passed, store campaign data
+        let campaign = CampaignData {
+            creator,
+            goal_amount,
+            raised_amount: 0,
+            end_time,
+            status: CampaignStatus::Active,
+            accepted_assets,
+            milestone_count: milestones.len() as u32,
+        };
+
+        set_campaign(&env, &campaign);
+
+        // Store each milestone
+        for (index, milestone) in milestones.iter().enumerate() {
+            set_milestone(&env, index as u32, milestone);
+        }
+
+        Ok(())
+    }
+
     pub fn hello(env: Env) -> soroban_sdk::Symbol {
         soroban_sdk::Symbol::new(&env, "campaign")
     }
 }
+
+/// Helper function to validate milestone conditions
+fn validate_milestones(
+    env: &Env,
+    milestones: &Vec<MilestoneData>,
+    goal_amount: i128,
+) -> Result<(), Error> {
+    // Check if milestones are sorted ascending by target_amount
+    for i in 1..milestones.len() {
+        let prev = &milestones.get(i - 1).unwrap();
+        let current = &milestones.get(i).unwrap();
+
+        if prev.target_amount >= current.target_amount {
+            panic_with_error(env, Error::InvalidMilestones);
+        }
+    }
+
+    // Check if last milestone.target_amount == goal_amount
+    if let Some(last_milestone) = milestones.last() {
+        if last_milestone.target_amount != goal_amount {
+            panic_with_error(env, Error::MilestoneMismatch);
+        }
+    } else {
+        panic_with_error(env, Error::InvalidMilestones);
+    }
+
+    Ok(())
+}
+
+/// Helper function to panic with a descriptive error message
+fn panic_with_error(env: &Env, error: Error) -> ! {
+    match error {
+        Error::InvalidGoalAmount => {
+            env.panic_with_error(soroban_sdk::Symbol::new(env, "InvalidGoalAmount"))
+        }
+        Error::InvalidEndTime => {
+            env.panic_with_error(soroban_sdk::Symbol::new(env, "InvalidEndTime"))
+        }
+        Error::InvalidAssets => {
+            env.panic_with_error(soroban_sdk::Symbol::new(env, "InvalidAssets"))
+        }
+        Error::InvalidMilestones => {
+            env.panic_with_error(soroban_sdk::Symbol::new(env, "InvalidMilestones"))
+        }
+        Error::MilestoneMismatch => {
+            env.panic_with_error(soroban_sdk::Symbol::new(env, "MilestoneMismatch"))
+        }
+    }
+}
+

--- a/campaign/src/types.rs
+++ b/campaign/src/types.rs
@@ -1,5 +1,18 @@
 use soroban_sdk::{contracttype, Address, BytesN, Vec};
 
+// ── Error enum ──────────────────────────────────────────────────────────────
+
+/// Initialization validation errors
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    InvalidGoalAmount,    // goal_amount must be > 0
+    InvalidEndTime,       // end_time must be > current ledger timestamp
+    InvalidAssets,        // accepted_assets must be non-empty
+    InvalidMilestones,    // milestones must be sorted ascending and last must equal goal
+    MilestoneMismatch,    // last milestone.target_amount != goal_amount
+}
+
 // ── Supporting enums ─────────────────────────────────────────────────────────
 
 /// Issue #167 – campaign lifecycle status


### PR DESCRIPTION
## Implementation Complete ✅

I've successfully implemented strict validation on campaign initialization. Here's what was done:

### **1. Added Error Types** (types.rs)
Added a comprehensive `Error` enum with five descriptive error variants:
- `InvalidGoalAmount` - when goal_amount ≤ 0
- `InvalidEndTime` - when end_time ≤ current ledger timestamp
- `InvalidAssets` - when accepted_assets is empty
- `InvalidMilestones` - when milestones aren't sorted or other milestone issues
- `MilestoneMismatch` - when last milestone.target_amount ≠ goal_amount

### **2. Implemented `initialize()` Function** (lib.rs)
The function enforces all acceptance criteria in sequence:

1. **goal_amount > 0** ✓ - Validates and panics with `InvalidGoalAmount`
2. **end_time > current ledger timestamp** ✓ - Uses `env.ledger().timestamp()` for comparison
3. **accepted_assets non-empty** ✓ - Validates and panics with `InvalidAssets`
4. **milestones sorted ascending** ✓ - Validates each milestone is greater than the previous
5. **last milestone.target_amount == goal_amount** ✓ - Ensures milestone alignment with goal
6. **Descriptive error panics** ✓ - Each validation panics with appropriate error symbols

### **3. Helper Functions**
- `validate_milestones()` - Ensures milestones are properly sorted and the last equals goal_amount
- `panic_with_error()` - Converts error types to descriptive panic messages using `env.panic_with_error()`

### **Key Features:**
- ✅ Validations occur in logical order (fail-fast approach)
- ✅ All inputs stored only after all validations pass
- ✅ Milestones stored individually in persistent storage
- ✅ Campaign initialized with `Active` status and 0 raised_amount
- ✅ Comprehensive error messages for debugging invalid deployments

The implementation prevents invalid campaigns from being deployed and provides clear error messaging for all failure scenarios.

Made changes.

closes #173 