### PR TITLE
Implement get_milestone view function

### DIFF
--- a/campaign/src/get_milestone.rs
+++ b/campaign/src/get_milestone.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{contract, contractimpl, Env};
+use crate::types::{Error, MilestoneData};
+use crate::storage::get_milestone;
+
+/// Issue #199 â€“ `get_milestone` view function
+///
+/// Returns the full `MilestoneData` for the milestone at `index`.
+/// Panics with `Error::MilestoneNotFound` if the index is out of range.
+/// No authentication required.
+pub fn get_milestone_view(env: &Env, index: u32) -> MilestoneData {
+    get_milestone(env, index).unwrap_or_else(|| {
+        soroban_sdk::panic_with_error!(env, Error::MilestoneNotFound)
+    })
+}


### PR DESCRIPTION
Adds `campaign/src/get_milestone.rs` implementing `get_milestone_view(env, index)` that returns full `MilestoneData` or panics with `Error::MilestoneNotFound`.

closes #199