### PR TITLE
feat: implement donation_received and milestone_unlocked events

### DIFF
--- a/campaign/src/event.rs
+++ b/campaign/src/event.rs
@@ -1,4 +1,26 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, String, Symbol};
+
+pub fn donation_received(
+    env: &Env,
+    donor: &Address,
+    amount: i128,
+    asset_code: String,
+    raised_total: i128,
+    timestamp: u64,
+) {
+    let topics = (Symbol::new(env, "donation_received"), env.current_contract_address());
+    env.events().publish(topics, (donor, amount, asset_code, raised_total, timestamp));
+}
+
+pub fn milestone_unlocked(
+    env: &Env,
+    milestone_index: u32,
+    target_amount: i128,
+    raised_total: i128,
+) {
+    let topics = (Symbol::new(env, "milestone_unlocked"), env.current_contract_address());
+    env.events().publish(topics, (milestone_index, target_amount, raised_total));
+}
 
 pub fn deadline_extended(
     env: &Env,
@@ -8,32 +30,14 @@ pub fn deadline_extended(
 ) {
     env.events().publish(
         ("campaign", "deadline_extended"),
-        (
-            creator,
-            old_deadline,
-            new_deadline,
-        ),
+        (creator, old_deadline, new_deadline),
     );
 }
 
-use soroban_sdk::{Address, Env};
-
-pub fn campaign_cancelled(
-    env: &Env,
-    creator: &Address,
-) {
-    env.events().publish(
-        ("campaign", "campaign_cancelled"),
-        creator,
-    );
+pub fn campaign_cancelled(env: &Env, creator: &Address) {
+    env.events().publish(("campaign", "campaign_cancelled"), creator);
 }
-
-use soroban_sdk::Env;
 
 pub fn campaign_ended(env: &Env) {
-    env.events().publish(
-        ("campaign", "campaign_ended"),
-        (),
-    );
+    env.events().publish(("campaign", "campaign_ended"), ());
 }
-

--- a/campaign/src/lib.rs
+++ b/campaign/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 
+pub mod event;
 pub mod storage;
 pub mod types;
 
-use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 use types::{CampaignData, CampaignInitializedEvent, CampaignStatus, DonorRecord, Error, MilestoneData, MilestoneStatus, StellarAsset, AssetInfo};
 use storage::{get_campaign, set_campaign, get_milestone, set_milestone, get_donor, set_donor, get_total_raised as storage_get_total_raised, set_total_raised};
 
@@ -157,15 +158,15 @@ impl CampaignContract {
                 {
                     milestone.status = MilestoneStatus::Unlocked;
                     set_milestone(&env, i, &milestone);
-                    env.events().publish(
-                        ("campaign", "milestone_unlocked"),
-                        (i, milestone.target_amount),
-                    );
+                    // Issue #229 – emit milestone_unlocked event
+                    event::milestone_unlocked(&env, i, milestone.target_amount, campaign.raised_amount);
                 }
             }
         }
 
-        env.events().publish(("campaign", "donation_received"), (donor, amount));
+        // Issue #228 – emit donation_received event with required schema
+        let asset_code = resolve_asset_code(&env, &asset, &campaign);
+        event::donation_received(&env, &donor, amount, asset_code, campaign.raised_amount, env.ledger().timestamp());
     }
 
     /// Issue #197 – Returns the total amount raised by the campaign.
@@ -267,6 +268,22 @@ fn validate_milestones(
     }
 
     Ok(())
+}
+
+/// Resolves the asset code string for an AssetInfo.
+/// For Native XLM returns "XLM"; for Stellar(addr) looks up the code in accepted_assets.
+fn resolve_asset_code(env: &Env, asset: &AssetInfo, campaign: &CampaignData) -> String {
+    match asset {
+        AssetInfo::Native => String::from_str(env, "XLM"),
+        AssetInfo::Stellar(addr) => {
+            campaign
+                .accepted_assets
+                .iter()
+                .find(|a| a.issuer == Some(addr.clone()))
+                .map(|a| a.asset_code.clone())
+                .unwrap_or_else(|| String::from_str(env, "UNKNOWN"))
+        }
+    }
 }
 
 /// Panics the contract execution with the given error code.

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,138 @@
+# Contract Event Schemas
+
+All events are emitted via `env.events().publish(topics, data)` and are filterable through Stellar Horizon's event streaming API.
+
+---
+
+## `campaign_initialized`
+
+Emitted once when the campaign contract is successfully initialized.
+
+**Topics:** `["campaign", "initialized"]`
+
+**Data:**
+
+| Field | Type | Description |
+|---|---|---|
+| `creator` | `Address` | Campaign creator's Stellar address |
+| `goal_amount` | `i128` | Total funding target in base units |
+| `end_time` | `u64` | UNIX timestamp after which donations are rejected |
+| `asset_count` | `u32` | Number of accepted assets |
+| `milestone_count` | `u32` | Number of milestones registered |
+
+---
+
+## `donation_received`
+
+Emitted after every successful donation, once storage has been updated.
+
+**Topics:** `["donation_received", contract_address]`
+
+**Data:**
+
+| Field | Type | Description |
+|---|---|---|
+| `donor` | `Address` | Donor's Stellar address |
+| `amount` | `i128` | Donated amount in base units |
+| `asset_code` | `String` | Asset code (e.g. `"XLM"`, `"USDC"`) |
+| `raised_total` | `i128` | Cumulative raised amount after this donation |
+| `timestamp` | `u64` | Ledger timestamp of the donation |
+
+---
+
+## `milestone_unlocked`
+
+Emitted once per milestone when its target is first reached. Not re-emitted if the milestone is already unlocked.
+
+**Topics:** `["milestone_unlocked", contract_address]`
+
+**Data:**
+
+| Field | Type | Description |
+|---|---|---|
+| `milestone_index` | `u32` | Zero-based milestone index |
+| `target_amount` | `i128` | Funding threshold that triggered the unlock |
+| `raised_total` | `i128` | Cumulative raised amount at time of unlock |
+
+---
+
+## `milestone_released`
+
+Emitted when a milestone's funds are released to the beneficiary.
+
+**Topics:** `["campaign", "milestone_released"]`
+
+**Data:**
+
+| Field | Type | Description |
+|---|---|---|
+| `milestone_index` | `u32` | Zero-based milestone index |
+| `scheduled_release` | `i128` | Amount scheduled for release |
+| `total_released` | `i128` | Cumulative released amount for this milestone |
+| `assets_released` | `u32` | Number of asset types released |
+| `recipient` | `Address` | Address that received the funds |
+
+---
+
+## `campaign_ended`
+
+Emitted when the campaign transitions to the `Ended` state (deadline passed or concluded normally).
+
+**Topics:** `["campaign", "campaign_ended"]`
+
+**Data:** `()` (no additional data)
+
+---
+
+## `campaign_cancelled`
+
+Emitted when the campaign creator cancels the campaign.
+
+**Topics:** `["campaign", "campaign_cancelled"]`
+
+**Data:**
+
+| Field | Type | Description |
+|---|---|---|
+| `creator` | `Address` | Campaign creator's Stellar address |
+
+---
+
+## `refund_issued`
+
+Emitted when a donor successfully claims a refund.
+
+**Topics:** `["campaign", "refund_issued"]`
+
+**Data:**
+
+| Field | Type | Description |
+|---|---|---|
+| `donor` | `Address` | Donor's Stellar address |
+| `amount` | `i128` | Refunded amount in base units |
+| `asset` | `AssetInfo` | Asset used for the refund |
+
+---
+
+## `deadline_extended`
+
+Emitted when the campaign creator extends the campaign deadline.
+
+**Topics:** `["campaign", "deadline_extended"]`
+
+**Data:**
+
+| Field | Type | Description |
+|---|---|---|
+| `creator` | `Address` | Campaign creator's Stellar address |
+| `old_deadline` | `u64` | Previous deadline UNIX timestamp |
+| `new_deadline` | `u64` | New deadline UNIX timestamp |
+
+---
+
+## Naming Convention
+
+- Event names use `snake_case`.
+- Topics are a tuple of `(event_name, contract_address)` for domain events, or `("campaign", event_name)` for lifecycle events.
+- All amounts are in base units (stroops for XLM, smallest unit for other assets).
+- All timestamps are UNIX seconds from the Soroban ledger (`env.ledger().timestamp()`).


### PR DESCRIPTION
## Summary

Implements the required contract events for the StellarAid campaign contract.

### Changes

**`campaign/src/event.rs`**
- Added `donation_received` event with topics `["donation_received", contract_address]` and data `{ donor, amount, asset_code, raised_total, timestamp }`
- Added `milestone_unlocked` event with topics `["milestone_unlocked", contract_address]` and data `{ milestone_index, target_amount, raised_total }`

**`campaign/src/lib.rs`**
- Declared `pub mod event`
- Updated `donate()` to emit both events via the event module
- Added `resolve_asset_code` helper to derive asset code string from `AssetInfo`

**`docs/events.md`**
- Documents all 8 contract event schemas with topics, data fields, and emission conditions

Closes #227
Closes #228
Closes #229