### PR TITLE
feat: implement milestone_released event (#230)

### DIFF
--- a/campaign/src/event.rs
+++ b/campaign/src/event.rs
@@ -41,3 +41,15 @@ pub fn campaign_cancelled(env: &Env, creator: &Address) {
 pub fn campaign_ended(env: &Env) {
     env.events().publish(("campaign", "campaign_ended"), ());
 }
+
+pub fn milestone_released(
+    env: &Env,
+    milestone_index: u32,
+    amount: i128,
+    asset_code: String,
+    recipient: &Address,
+    timestamp: u64,
+) {
+    let topics = (Symbol::new(env, "milestone_released"), env.current_contract_address());
+    env.events().publish(topics, (milestone_index, amount, asset_code, recipient, timestamp));
+}

--- a/campaign/src/multi_asset_release.rs
+++ b/campaign/src/multi_asset_release.rs
@@ -1,6 +1,7 @@
 
 
 use soroban_sdk::{panic_with_error, symbol_short, token, Address, Env, Vec};
+use crate::event;
 use crate::types::{Error, MilestoneStatus, StellarAsset};
 use crate::storage::{
     get_campaign, get_milestone, set_milestone,
@@ -122,8 +123,8 @@ pub fn release_milestone_multi_asset(
     set_milestone(env, milestone_index, &milestone);
 
     // ── 7. Execute proportional transfers ───────────────────────────────────
+    let timestamp = env.ledger().timestamp();
     let mut total_released: i128 = 0;
-    let mut assets_released: u32 = 0;
 
     for asset in campaign.accepted_assets.iter() {
         let token_address = match &asset.issuer {
@@ -176,6 +177,16 @@ pub fn release_milestone_multi_asset(
             &clamped_release,
         );
 
+        // Emit per-asset milestone_released event
+        event::milestone_released(
+            env,
+            milestone_index,
+            clamped_release,
+            asset.asset_code.clone(),
+            &recipient,
+            timestamp,
+        );
+
         // Update per-asset accounting
         let new_asset_raised = asset_raised
             .checked_sub(clamped_release)
@@ -186,7 +197,6 @@ pub fn release_milestone_multi_asset(
         total_released = total_released
             .checked_add(clamped_release)
             .unwrap_or_else(|| panic_with_error!(env, Error::Overflow));
-        assets_released += 1;
     }
 
     // ── 8. Update global total-raised bookkeeping ────────────────────────────
@@ -196,17 +206,6 @@ pub fn release_milestone_multi_asset(
         .max(0);
     storage_set_total_raised(env, new_total_raised);
 
-    // ── 9. Emit structured event ─────────────────────────────────────────────
-    env.events().publish(
-        (symbol_short!("milestone"), symbol_short!("ms_rel")),
-        (
-            milestone_index,
-            milestone_release,   // amount scheduled for release
-            total_released,      // amount actually transferred (may differ by dust)
-            assets_released,     // number of assets touched
-            recipient.clone(),
-        ),
-    );
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────

--- a/campaign/src/release_milestone.rs
+++ b/campaign/src/release_milestone.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{Address, Env, token};
+use crate::event;
 use crate::types::{Error, MilestoneStatus};
 use crate::storage::{get_campaign, get_milestone, set_milestone};
 
@@ -30,6 +31,8 @@ pub fn release_milestone(env: &Env, milestone_index: u32, recipient: Address) {
         .checked_sub(milestone.released_amount)
         .unwrap_or_else(|| soroban_sdk::panic_with_error!(env, Error::Overflow));
 
+    let timestamp = env.ledger().timestamp();
+
     // Transfer each accepted asset proportionally
     for asset in campaign.accepted_assets.iter() {
         if let Some(issuer) = asset.issuer.clone() {
@@ -38,6 +41,15 @@ pub fn release_milestone(env: &Env, milestone_index: u32, recipient: Address) {
             if asset_balance > 0 && release_amount > 0 {
                 let transfer_amount = release_amount.min(asset_balance);
                 token_client.transfer(&env.current_contract_address(), &recipient, &transfer_amount);
+
+                event::milestone_released(
+                    env,
+                    milestone_index,
+                    transfer_amount,
+                    asset.asset_code.clone(),
+                    &recipient,
+                    timestamp,
+                );
             }
         }
     }
@@ -45,9 +57,4 @@ pub fn release_milestone(env: &Env, milestone_index: u32, recipient: Address) {
     milestone.released_amount = milestone.target_amount;
     milestone.status = MilestoneStatus::Released;
     set_milestone(env, milestone_index, &milestone);
-
-    env.events().publish(
-        ("milestone", "released"),
-        (milestone_index, release_amount, recipient),
-    );
 }

--- a/campaign/src/types.rs
+++ b/campaign/src/types.rs
@@ -471,16 +471,16 @@ pub struct DonationReceivedEvent {
     pub ledger: u32,
 }
 
-/// Emitted by `release_milestone_multi_asset`.
+/// Emitted by `release_milestone` and `release_milestone_multi_asset`.
+/// One event per asset transfer.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MilestoneReleasedEvent {
     pub milestone_index: u32,
-    pub scheduled_release: i128,
-    pub total_released: i128,
-    pub assets_released: u32,
+    pub amount: i128,
+    pub asset_code: String,
     pub recipient: Address,
-    pub ledger: u32,
+    pub timestamp: u64,
 }
 
 /// Emitted by campaign status transitions.

--- a/docs/events.md
+++ b/docs/events.md
@@ -58,19 +58,21 @@ Emitted once per milestone when its target is first reached. Not re-emitted if t
 
 ## `milestone_released`
 
-Emitted when a milestone's funds are released to the beneficiary.
+Emitted after each successful token transfer during milestone release.
+When a multi-asset release transfers tokens from multiple assets, a separate event
+is emitted per asset.
 
-**Topics:** `["campaign", "milestone_released"]`
+**Topics:** `["milestone_released", contract_address]`
 
 **Data:**
 
 | Field | Type | Description |
 |---|---|---|
 | `milestone_index` | `u32` | Zero-based milestone index |
-| `scheduled_release` | `i128` | Amount scheduled for release |
-| `total_released` | `i128` | Cumulative released amount for this milestone |
-| `assets_released` | `u32` | Number of asset types released |
+| `amount` | `i128` | Amount transferred in this asset's base units |
+| `asset_code` | `String` | Asset code (e.g. `"XLM"`, `"USDC"`) |
 | `recipient` | `Address` | Address that received the funds |
+| `timestamp` | `u64` | Ledger timestamp of the release |
 
 ---
 


### PR DESCRIPTION
Implement `milestone_released` event

Adds a `milestone_released` event emitted after each successful token
transfer during milestone fund release. Per the acceptance criteria:

- **Topics:** `["milestone_released", contract_address]`
- **Data:** `(milestone_index: u32, amount: i128, asset_code: String, recipient: Address, timestamp: u64)`
- Emitted after each successful token transfer inside the release loop
- Separate event per asset for multi-asset releases (replaces the old aggregate event)

### Changes
- `event.rs`: Add `milestone_released()` helper following existing events pattern
- `release_milestone.rs`: Emit per-asset events inside transfer loop
- `multi_asset_release.rs`: Emit per-asset events inside transfer loop; remove old aggregate event
- `types.rs`: Update `MilestoneReleasedEvent` struct to match new per-asset schema
- `docs/events.md`: Update documentation to match new topic/data format

### Risk
Low. Adds event emission after existing transfer operations;
no change to control flow, storage, or authorization logic.
Rollback: Revert the commit.

Closes #230