### PR TITLE
Feat/issues223

### DIFF
--- a/campaign/src/lib.rs
+++ b/campaign/src/lib.rs
@@ -5,7 +5,7 @@ pub mod types;
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
 use types::{CampaignData, CampaignInitializedEvent, CampaignStatus, DonorRecord, Error, MilestoneData, MilestoneStatus, StellarAsset, AssetInfo};
-use storage::{get_campaign, set_campaign, get_milestone, set_milestone, get_donor, set_donor, get_total_raised as storage_get_total_raised, set_total_raised};
+use storage::{get_campaign, set_campaign, get_milestone, set_milestone, get_donor, set_donor, get_total_raised as storage_get_total_raised, set_total_raised, increment_donor_asset_donation, get_donor_asset_donation};
 
 pub const VERSION: u32 = 1;
 
@@ -141,6 +141,10 @@ impl CampaignContract {
         let new_total = storage_get_total_raised(&env) + amount;
         set_total_raised(&env, new_total);
 
+        // Track per-asset donation for pro-rata refund calculation
+        let asset_address = get_token_address_for_asset(&env, &asset, &campaign);
+        increment_donor_asset_donation(&env, &donor, &asset_address, amount);
+
         // Issue #195 – update donor record
         let mut donor_record = get_donor(&env, &donor).unwrap_or(DonorRecord {
             donor: donor.clone(),
@@ -243,8 +247,10 @@ impl CampaignContract {
 
     /// Claim a refund for a donation.
     ///
-    /// Transfers the donor's full donation amount back to them, proportionally
-    /// across all accepted assets. Marks the donor's refund_claimed flag as true.
+    /// Calculates pro-rata refund based on milestone releases:
+    /// - refund_amount = donor_contribution * (raised_amount - total_released) / raised_amount
+    /// 
+    /// Transfers refund per asset separately. Marks the donor's refund_claimed flag as true.
     ///
     /// # Panics
     /// - `Error::NotInitialized` if campaign not initialized
@@ -282,11 +288,51 @@ impl CampaignContract {
             panic_with_error(&env, Error::RefundAlreadyClaimed);
         }
 
-        // Mark refund as claimed
+        // Calculate total released across all milestones
+        let mut total_released: i128 = 0;
+        for i in 0..campaign.milestone_count {
+            if let Some(milestone) = get_milestone(&env, i) {
+                total_released += milestone.released_amount;
+            }
+        }
+
+        // Calculate refund multiplier: (raised - released) / raised
+        // This gives the fraction of the donation that should be refunded
+        let refund_numerator = campaign.raised_amount - total_released;
+        let refund_denominator = campaign.raised_amount;
+
+        // Mark refund as claimed early to prevent reentrancy
         donor_record.refund_claimed = true;
         set_donor(&env, &donor, &donor_record);
 
-        // Emit refund event
+        // For each asset the donor contributed to, calculate and transfer refund
+        for asset in campaign.accepted_assets.iter() {
+            let asset_address = asset.issuer.as_ref()
+                .unwrap_or_else(|| panic_with_error(&env, Error::MissingIssuerAddress));
+            
+            // Get amount donor contributed in this asset
+            let donor_asset_amount = get_donor_asset_donation(&env, &donor, asset_address);
+            
+            if donor_asset_amount > 0 {
+                // Calculate pro-rata refund: (donor_amount * refund_numerator) / refund_denominator
+                let refund_amount = (donor_asset_amount * refund_numerator) / refund_denominator;
+                
+                if refund_amount > 0 {
+                    // Transfer refund to donor
+                    use soroban_sdk::token;
+                    let token_client = token::Client::new(&env, asset_address);
+                    token_client.transfer(&env.current_contract_address(), &donor, &refund_amount);
+
+                    // Emit event for this asset's refund
+                    env.events().publish(
+                        ("campaign", "asset_refund"),
+                        (donor.clone(), asset_address.clone(), refund_amount),
+                    );
+                }
+            }
+        }
+
+        // Emit overall refund claimed event
         env.events().publish(
             ("campaign", "refund_claimed"),
             (&donor, donor_record.total_donated),

--- a/campaign/src/lib.rs
+++ b/campaign/src/lib.rs
@@ -198,13 +198,17 @@ impl CampaignContract {
 
     /// Check if a donor is eligible to claim a refund.
     ///
-    /// Returns `true` if:
-    /// - Campaign is in a terminal state (Ended or Cancelled)
-    /// - Goal was NOT reached (refunds only for failed campaigns)
-    /// - Current time is within the refund window (≤ 30 days after end_time)
-    /// - Donor has not already claimed a refund
+    /// A donor is refund-eligible if ALL of the following are true:
+    /// 1. Campaign is in terminal state (Ended or Cancelled)
+    /// 2. Refunds are allowed per campaign status:
+    ///    - `Cancelled`: always allow refunds
+    ///    - `Ended`: only if NO milestones have been Released yet
+    /// 3. Current time is within the refund window (≤ 30 days after end_time)
+    /// 4. Donor has never claimed a refund before
+    /// 5. Donor has made at least one donation
     ///
-    /// No auth required (view function).
+    /// This view function exposes the on-chain refund policy transparently.
+    /// No auth required (read-only).
     pub fn is_refund_eligible(env: Env, donor: Address) -> bool {
         let campaign = match get_campaign(&env) {
             Some(c) => c,
@@ -216,28 +220,36 @@ impl CampaignContract {
             None => return false,
         };
 
-        // Refunds only available when campaign is in terminal state
+        // Check 1: Campaign must be in terminal state
         if !campaign.status.is_terminal() {
             return false;
         }
 
-        // Refunds only for failed campaigns (Cancelled or Ended without goal)
-        if !campaign.status.allows_refunds() {
-            return false;
+        // Check 2: Refunds allowed based on campaign status
+        match campaign.status {
+            CampaignStatus::Cancelled => {
+                // Refunds always allowed for cancelled campaigns
+            }
+            CampaignStatus::Ended => {
+                // Refunds only if NO milestones have been released yet
+                for i in 0..campaign.milestone_count {
+                    if let Some(milestone) = get_milestone(&env, i) {
+                        if milestone.status == MilestoneStatus::Released {
+                            return false; // A milestone was already released
+                        }
+                    }
+                }
+            }
+            _ => return false, // Active and GoalReached are not terminal
         }
 
-        // For Ended status, goal must not have been reached
-        if campaign.status == CampaignStatus::Ended && campaign.goal_reached() {
-            return false;
-        }
-
-        // Check refund window: current_time <= end_time + REFUND_WINDOW
+        // Check 3: Current time within refund window (≤ end_time + REFUND_WINDOW)
         let current_time = env.ledger().timestamp();
         if current_time > campaign.end_time + REFUND_WINDOW {
             return false;
         }
 
-        // Donor must not have already claimed refund
+        // Check 4: Donor must not have already claimed refund
         if donor_record.refund_claimed {
             return false;
         }
@@ -247,15 +259,24 @@ impl CampaignContract {
 
     /// Claim a refund for a donation.
     ///
-    /// Calculates pro-rata refund based on milestone releases:
-    /// - refund_amount = donor_contribution * (raised_amount - total_released) / raised_amount
-    /// 
-    /// Transfers refund per asset separately. Marks the donor's refund_claimed flag as true.
+    /// Eligibility Rules (enforced in order):
+    /// 1. Campaign must be in a terminal state (Ended or Cancelled)
+    /// 2. For Cancelled campaigns: refund always available (if within window)
+    /// 3. For Ended campaigns: NO milestones must have been Released yet
+    /// 4. Current time must be within the 30-day refund window after end_time
+    /// 5. Donor must not have already claimed a refund
+    ///
+    /// Refund Calculation (Pro-rata):
+    /// - Total released = sum of released_amount across all milestones
+    /// - Refund % = (raised_amount - total_released) / raised_amount
+    /// - Per-asset refund = donor_asset_amount × refund%
+    ///
+    /// Each asset is transferred separately to the donor.
     ///
     /// # Panics
     /// - `Error::NotInitialized` if campaign not initialized
     /// - `Error::NoDonorRecord` if donor has never donated
-    /// - `Error::RefundNotPermitted` if campaign is not in terminal state or goal was reached
+    /// - `Error::RefundNotPermitted` if milestone already released
     /// - `Error::RefundWindowClosed` if current time > end_time + REFUND_WINDOW
     /// - `Error::RefundAlreadyClaimed` if donor already claimed refund
     pub fn claim_refund(env: Env, donor: Address) {
@@ -267,23 +288,36 @@ impl CampaignContract {
         let mut donor_record = get_donor(&env, &donor)
             .unwrap_or_else(|| panic_with_error(&env, Error::NoDonorRecord));
 
-        // Check campaign status allows refunds
-        if !campaign.status.allows_refunds() {
+        // Eligibility Check 1: Campaign must be terminal
+        if !campaign.status.is_terminal() {
             panic_with_error(&env, Error::RefundNotPermitted);
         }
 
-        // For Ended campaigns, only allow refunds if goal was NOT reached
-        if campaign.status == CampaignStatus::Ended && campaign.goal_reached() {
-            panic_with_error(&env, Error::RefundNotPermitted);
+        // Eligibility Check 2-3: Status-specific rules
+        match campaign.status {
+            CampaignStatus::Cancelled => {
+                // Refunds always allowed for cancelled campaigns
+            }
+            CampaignStatus::Ended => {
+                // Refunds only if NO milestones have been released
+                for i in 0..campaign.milestone_count {
+                    if let Some(milestone) = get_milestone(&env, i) {
+                        if milestone.status == MilestoneStatus::Released {
+                            panic_with_error(&env, Error::RefundNotPermitted);
+                        }
+                    }
+                }
+            }
+            _ => panic_with_error(&env, Error::RefundNotPermitted),
         }
 
-        // Check refund window: current_time <= end_time + REFUND_WINDOW
+        // Eligibility Check 4: Refund window
         let current_time = env.ledger().timestamp();
         if current_time > campaign.end_time + REFUND_WINDOW {
             panic_with_error(&env, Error::RefundWindowClosed);
         }
 
-        // Prevent double refunds
+        // Eligibility Check 5: Prevent double refunds
         if donor_record.refund_claimed {
             panic_with_error(&env, Error::RefundAlreadyClaimed);
         }
@@ -416,6 +450,14 @@ fn validate_milestones(
     } else {
         panic_with_error(env, Error::InvalidMilestones);
     }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    pub mod refund_eligibility_tests;
+}
 
     Ok(())
 }

--- a/campaign/src/storage.rs
+++ b/campaign/src/storage.rs
@@ -116,6 +116,38 @@ pub fn get_donor_or_default(env: &Env, donor: &Address) -> DonorRecord {
     })
 }
 
+// ─── Per-asset donor donations ────────────────────────────────────────────────
+
+/// Get the amount a donor has contributed in a specific asset.
+/// Returns 0 if no donations in that asset yet.
+pub fn get_donor_asset_donation(env: &Env, donor: &Address, asset: &Address) -> i128 {
+    let key = DataKey::DonorAssetDonation(donor.clone(), asset.clone());
+    let value: i128 = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(0);
+    bump_persistent(env, &key);
+    value
+}
+
+/// Add to a donor's contribution in a specific asset.
+/// Panics if the addition would overflow.
+pub fn increment_donor_asset_donation(env: &Env, donor: &Address, asset: &Address, amount: i128) {
+    let key = DataKey::DonorAssetDonation(donor.clone(), asset.clone());
+    let current: i128 = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(0);
+    
+    let new_amount = current.checked_add(amount)
+        .unwrap_or_else(|| panic_with_error!(env, Error::ArithmeticOverflow));
+    
+    env.storage().persistent().set(&key, &new_amount);
+    bump_persistent(env, &key);
+}
+
 // ─── Total raised ─────────────────────────────────────────────────────────────
 
 /// Load the global total-raised counter. Returns 0 before any donations.

--- a/campaign/src/test/refund_eligibility_tests.rs
+++ b/campaign/src/test/refund_eligibility_tests.rs
@@ -1,0 +1,239 @@
+#![cfg(test)]
+
+use soroban_sdk::testutils::Address as AddressTestUtils;
+use soroban_sdk::{Address, Env};
+
+use crate::types::{CampaignStatus, CampaignData, DonorRecord, AssetInfo, StellarAsset, MilestoneStatus};
+use crate::storage::{set_campaign, set_donor, get_milestone, set_milestone};
+use crate::CampaignContract;
+
+/// Helper to create a test milestone
+fn create_test_milestone(
+    env: &Env,
+    campaign_index: u32,
+    status: MilestoneStatus,
+) {
+    let milestone = crate::types::MilestoneData {
+        index: campaign_index,
+        target_amount: 1000,
+        released_amount: 0,
+        description_hash: soroban_sdk::BytesN::from_array(env, &[0u8; 32]),
+        status,
+        released_at: None,
+        released_at_ledger: None,
+        release_tx: None,
+        released_to: None,
+    };
+    set_milestone(env, campaign_index, &milestone);
+}
+
+/// Helper to create a test campaign
+fn create_test_campaign(
+    env: &Env,
+    status: CampaignStatus,
+    goal_amount: i128,
+    end_time: u64,
+) -> CampaignData {
+    let creator = Address::generate(env);
+    let campaign = CampaignData {
+        creator: creator.clone(),
+        goal_amount,
+        raised_amount: 0,
+        end_time,
+        status,
+        accepted_assets: {
+            let mut assets = soroban_sdk::Vec::new(env);
+            assets.push_back(StellarAsset {
+                asset_code: soroban_sdk::String::from_str(env, "XLM"),
+                issuer: Some(Address::generate(env)),
+            });
+            assets
+        },
+        milestone_count: 1,
+        min_donation_amount: 0,
+        created_at_ledger: 0,
+        created_at_time: 0,
+        concluded_at_ledger: None,
+    };
+    set_campaign(env, &campaign);
+    // Create the milestone for this campaign
+    create_test_milestone(env, 0, MilestoneStatus::Locked);
+    campaign
+}
+
+/// Helper to create a test donor record
+fn create_test_donor(
+    env: &Env,
+    donor: &Address,
+    total_donated: i128,
+    refund_claimed: bool,
+) -> DonorRecord {
+    let donor_record = DonorRecord {
+        donor: donor.clone(),
+        total_donated,
+        asset: AssetInfo::Native,
+        last_donation_time: 0,
+        last_donation_ledger: 0,
+        donation_count: 1,
+        refund_claimed,
+    };
+    set_donor(env, donor, &donor_record);
+    donor_record
+}
+
+#[test]
+fn test_refund_not_eligible_campaign_active() {
+    let env = Env::default();
+    let end_time = env.ledger().timestamp() + 1000;
+    create_test_campaign(&env, CampaignStatus::Active, 1000, end_time);
+    
+    let donor = Address::generate(&env);
+    create_test_donor(&env, &donor, 100, false);
+
+    // Active campaigns don't allow refunds
+    let eligible = CampaignContract::is_refund_eligible(env.clone(), donor.clone());
+    assert!(!eligible, "Active campaign should not be refund-eligible");
+}
+
+#[test]
+fn test_refund_not_eligible_campaign_goal_reached() {
+    let env = Env::default();
+    let end_time = env.ledger().timestamp() + 1000;
+    create_test_campaign(&env, CampaignStatus::GoalReached, 1000, end_time);
+    
+    let donor = Address::generate(&env);
+    create_test_donor(&env, &donor, 100, false);
+
+    // GoalReached campaigns don't allow refunds
+    let eligible = CampaignContract::is_refund_eligible(env.clone(), donor.clone());
+    assert!(!eligible, "GoalReached campaign should not be refund-eligible");
+}
+
+#[test]
+fn test_refund_eligible_campaign_cancelled() {
+    let env = Env::default();
+    let end_time = env.ledger().timestamp() + 1000;
+    create_test_campaign(&env, CampaignStatus::Cancelled, 1000, end_time);
+    
+    let donor = Address::generate(&env);
+    create_test_donor(&env, &donor, 100, false);
+
+    // Cancelled campaigns always allow refunds (within window)
+    let eligible = CampaignContract::is_refund_eligible(env.clone(), donor.clone());
+    assert!(eligible, "Cancelled campaign should be refund-eligible");
+}
+
+#[test]
+fn test_refund_eligible_campaign_ended_no_milestone_released() {
+    let env = Env::default();
+    let end_time = env.ledger().timestamp() - 100; // Campaign ended
+    create_test_campaign(&env, CampaignStatus::Ended, 1000, end_time);
+    
+    let donor = Address::generate(&env);
+    create_test_donor(&env, &donor, 100, false);
+
+    // Ended campaigns allow refunds only if no milestone released
+    let eligible = CampaignContract::is_refund_eligible(env.clone(), donor.clone());
+    assert!(eligible, "Ended campaign with no milestone released should be refund-eligible");
+}
+
+#[test]
+fn test_refund_not_eligible_no_donor_record() {
+    let env = Env::default();
+    let end_time = env.ledger().timestamp() + 1000;
+    create_test_campaign(&env, CampaignStatus::Cancelled, 1000, end_time);
+    
+    let donor = Address::generate(&env);
+    // Don't create a donor record
+
+    // Non-donors can't get refunds
+    let eligible = CampaignContract::is_refund_eligible(env.clone(), donor.clone());
+    assert!(!eligible, "Non-donor should not be refund-eligible");
+}
+
+#[test]
+fn test_refund_not_eligible_no_campaign() {
+    let env = Env::default();
+    
+    let donor = Address::generate(&env);
+    create_test_donor(&env, &donor, 100, false);
+
+    // Can't refund if campaign doesn't exist
+    let eligible = CampaignContract::is_refund_eligible(env.clone(), donor.clone());
+    assert!(!eligible, "Should not be refund-eligible if campaign not initialized");
+}
+
+#[test]
+fn test_refund_not_eligible_window_closed() {
+    let env = Env::default();
+    // Campaign ended more than 30 days ago
+    let end_time = env.ledger().timestamp() - (31 * 24 * 60 * 60);
+    create_test_campaign(&env, CampaignStatus::Cancelled, 1000, end_time);
+    
+    let donor = Address::generate(&env);
+    create_test_donor(&env, &donor, 100, false);
+
+    // Window must be within 30 days
+    let eligible = CampaignContract::is_refund_eligible(env.clone(), donor.clone());
+    assert!(!eligible, "Refund should not be eligible after 30-day window closes");
+}
+
+#[test]
+fn test_refund_not_eligible_already_claimed() {
+    let env = Env::default();
+    let end_time = env.ledger().timestamp() + 1000;
+    create_test_campaign(&env, CampaignStatus::Cancelled, 1000, end_time);
+    
+    let donor = Address::generate(&env);
+    create_test_donor(&env, &donor, 100, true); // Already claimed
+
+    // Can't claim refund twice
+    let eligible = CampaignContract::is_refund_eligible(env.clone(), donor.clone());
+    assert!(!eligible, "Donor should not be refund-eligible if already claimed");
+}
+
+#[test]
+fn test_refund_window_edge_case_exactly_30_days() {
+    let env = Env::default();
+    // Campaign ended exactly 30 days ago
+    let end_time = env.ledger().timestamp() - (30 * 24 * 60 * 60);
+    create_test_campaign(&env, CampaignStatus::Cancelled, 1000, end_time);
+    
+    let donor = Address::generate(&env);
+    create_test_donor(&env, &donor, 100, false);
+
+    // Should be eligible at exactly 30 days
+    let eligible = CampaignContract::is_refund_eligible(env.clone(), donor.clone());
+    assert!(eligible, "Should be refund-eligible at exactly 30-day boundary");
+}
+
+#[test]
+fn test_refund_window_edge_case_one_second_after_30_days() {
+    let env = Env::default();
+    // Campaign ended 30 days + 1 second ago
+    let end_time = env.ledger().timestamp() - (30 * 24 * 60 * 60 + 1);
+    create_test_campaign(&env, CampaignStatus::Cancelled, 1000, end_time);
+    
+    let donor = Address::generate(&env);
+    create_test_donor(&env, &donor, 100, false);
+
+    // Should NOT be eligible past 30 days
+    let eligible = CampaignContract::is_refund_eligible(env.clone(), donor.clone());
+    assert!(!eligible, "Should not be refund-eligible after 30-day window closes");
+}
+
+#[test]
+fn test_refund_eligibility_all_conditions() {
+    // Test that all conditions must be true for eligibility
+    let env = Env::default();
+    let end_time = env.ledger().timestamp() + 1000;
+    
+    // Start with a cancelled campaign (eligible)
+    create_test_campaign(&env, CampaignStatus::Cancelled, 1000, end_time);
+    let donor = Address::generate(&env);
+    create_test_donor(&env, &donor, 100, false);
+
+    // Should be eligible
+    let eligible = CampaignContract::is_refund_eligible(env.clone(), donor.clone());
+    assert!(eligible, "Should be eligible with cancelled campaign, no claim, within window");
+}

--- a/campaign/src/types.rs
+++ b/campaign/src/types.rs
@@ -221,6 +221,9 @@ pub enum DataKey {
     TotalRaised,
     /// Per-token raised amount — keyed by the token contract address.
     AssetRaised(Address),
+    /// Per-asset donation by a donor — keyed by (donor_address, asset_address).
+    /// Tracks exact amount contributed in each asset for pro-rata refund calculation.
+    DonorAssetDonation(Address, Address),
 
     // ── Temporary ───────────────────────────────────────────────────────────
     /// Transient campaign status flag used during state transitions.


### PR DESCRIPTION
Closes #223
Implement refund eligibility logic with comprehensive test coverage

- Update is_refund_eligible() to check 'no milestone released' condition
- Eligibility rules:
Closes #155
  - Cancelled campaigns: always eligible (within window)
  - Ended campaigns: only if no milestones released (not just goal check)
- Add comprehensive test suite covering all eligibility conditions
Closes #149
- Test 10+ scenarios including edge cases for 30-day window
- Detailed documentation in contract comments"

Closes #224