### PR TITLE
Implement issues #337, #338, #339, #340 (Stellar Wave)

### DIFF
--- a/config/testnet_contracts.json
+++ b/config/testnet_contracts.json
@@ -1,0 +1,22 @@
+{
+  "network": "testnet",
+  "rpc_url": "https://soroban-testnet.stellar.org",
+  "network_passphrase": "Test SDF Network ; September 2015",
+  "contracts": {
+    "campaign": {
+      "id": "",
+      "wasm": "target/wasm32-unknown-unknown/release/campaign.wasm"
+    },
+    "donation": {
+      "id": "",
+      "wasm": "target/wasm32-unknown-unknown/release/donation.wasm",
+      "depends_on": ["campaign"]
+    },
+    "withdrawal": {
+      "id": "",
+      "wasm": "target/wasm32-unknown-unknown/release/withdrawal.wasm",
+      "depends_on": ["donation"]
+    }
+  },
+  "admin_address": ""
+}

--- a/contracts/campaign/src/lib.rs
+++ b/contracts/campaign/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{contract, contractimpl, contracttype, Symbol, Address, Env, String};
+use shared::pause;
 use shared::types::{Campaign, CampaignStatus};
 
 #[contracttype]
@@ -29,7 +30,20 @@ impl CampaignContract {
         env.storage().instance().set(&DataKey::Admin, &admin);
     }
 
+    pub fn pause(env: Env, admin: Address) {
+        admin.require_auth();
+        Self::ensure_admin(&env, &admin);
+        pause::pause(&env, &admin);
+    }
+
+    pub fn unpause(env: Env, admin: Address) {
+        admin.require_auth();
+        Self::ensure_admin(&env, &admin);
+        pause::unpause(&env, &admin);
+    }
+
     pub fn create_campaign(env: Env, owner: Address, goal: i128, deadline: u64) -> u64 {
+        pause::require_not_paused(&env);
         owner.require_auth();
         let id = Self::next_campaign_id(&env);
         let campaign = Campaign {
@@ -55,6 +69,7 @@ impl CampaignContract {
     }
 
     pub fn update_raised(env: Env, campaign_id: u64, amount: i128) {
+        pause::require_not_paused(&env);
         let mut campaign = env
             .storage()
             .persistent()
@@ -65,6 +80,7 @@ impl CampaignContract {
     }
 
     pub fn approve_campaign(env: Env, admin: Address, campaign_id: u64) {
+        pause::require_not_paused(&env);
         admin.require_auth();
         Self::ensure_admin(&env, &admin);
         let mut campaign = Self::get_campaign(env.clone(), campaign_id).unwrap();
@@ -73,6 +89,7 @@ impl CampaignContract {
     }
 
     pub fn reject_campaign(env: Env, admin: Address, campaign_id: u64, reason: String) {
+        pause::require_not_paused(&env);
         admin.require_auth();
         Self::ensure_admin(&env, &admin);
         let mut campaign = Self::get_campaign(env.clone(), campaign_id).unwrap();
@@ -82,6 +99,7 @@ impl CampaignContract {
     }
 
     pub fn suspend_campaign(env: Env, admin: Address, campaign_id: u64) {
+        pause::require_not_paused(&env);
         admin.require_auth();
         Self::ensure_admin(&env, &admin);
         let mut campaign = Self::get_campaign(env.clone(), campaign_id).unwrap();
@@ -90,6 +108,7 @@ impl CampaignContract {
     }
 
     pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) {
+        pause::require_not_paused(&env);
         current_admin.require_auth();
         Self::ensure_admin(&env, &current_admin);
         env.storage().instance().set(&DataKey::Admin, &new_admin);
@@ -138,5 +157,27 @@ mod test {
         client.reject_campaign(&admin, &campaign_id, &String::from_str(&env, "spam"));
         let rejected = client.get_campaign(&campaign_id).unwrap();
         assert_eq!(rejected.status, CampaignStatus::Rejected);
+    }
+
+    #[test]
+    fn pause_blocks_state_mutations() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, CampaignContract);
+        let client = CampaignContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let owner = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.pause(&admin);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.create_campaign(&owner, &1_000_i128, &2_000_u64);
+        }));
+        assert!(result.is_err());
+
+        client.unpause(&admin);
+        let campaign_id = client.create_campaign(&owner, &1_000_i128, &2_000_u64);
+        assert_eq!(campaign_id, 1);
     }
 }

--- a/contracts/donation/src/lib.rs
+++ b/contracts/donation/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{contract, contractclient, contractimpl, contracttype, Address, Env, Symbol, Vec};
+use shared::pause;
 use shared::types::Donation;
 
 #[contractclient(name = "CampaignContractClient")]
@@ -11,6 +12,7 @@ trait CampaignContractTrait {
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
+    Admin = 4,
     DonationHistory(Address) = 0,
     CampaignDonations(u64) = 1,
     CampaignRaised(u64) = 2,
@@ -30,11 +32,26 @@ pub struct DonationContract;
 
 #[contractimpl]
 impl DonationContract {
-    pub fn initialize(env: Env, campaign_contract: Address) {
+    pub fn initialize(env: Env, admin: Address, campaign_contract: Address) {
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::CampaignContract, &campaign_contract);
     }
 
+    pub fn pause(env: Env, admin: Address) {
+        admin.require_auth();
+        Self::ensure_admin(&env, &admin);
+        pause::pause(&env, &admin);
+    }
+
+    pub fn unpause(env: Env, admin: Address) {
+        admin.require_auth();
+        Self::ensure_admin(&env, &admin);
+        pause::unpause(&env, &admin);
+    }
+
     pub fn donate(env: Env, donor: Address, campaign_id: u64, amount: i128) {
+        pause::require_not_paused(&env);
         donor.require_auth();
         let mut donations = env.storage().persistent().get(&DataKey::CampaignDonations(campaign_id)).unwrap_or(Vec::new(&env));
         let timestamp = env.ledger().timestamp();
@@ -77,6 +94,13 @@ impl DonationContract {
     pub fn get_donor_history(env: Env, donor: Address) -> Vec<Donation> {
         env.storage().persistent().get(&DataKey::DonationHistory(donor)).unwrap_or(Vec::new(&env))
     }
+
+    fn ensure_admin(env: &Env, admin: &Address) {
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if stored_admin != *admin {
+            panic!("unauthorized");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -91,9 +115,10 @@ mod test {
         let contract_id = env.register_contract(None, DonationContract);
         let client = DonationContractClient::new(&env, &contract_id);
         let donor = Address::generate(&env);
+        let admin = Address::generate(&env);
         let campaign_contract = Address::generate(&env);
 
-        client.initialize(&campaign_contract);
+        client.initialize(&admin, &campaign_contract);
         client.donate(&donor, &7_u64, &100_i128);
 
         let donations = client.get_donations_for_campaign(&7_u64);
@@ -103,5 +128,28 @@ mod test {
         let history = client.get_donor_history(&donor);
         assert_eq!(history.len(), 1);
         assert_eq!(history.get(0).unwrap().amount, 100_i128);
+    }
+
+    #[test]
+    fn pause_blocks_donations() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+        let donor = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let campaign_contract = Address::generate(&env);
+
+        client.initialize(&admin, &campaign_contract);
+        client.pause(&admin);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.donate(&donor, &7_u64, &100_i128);
+        }));
+        assert!(result.is_err());
+
+        client.unpause(&admin);
+        client.donate(&donor, &7_u64, &100_i128);
+        assert_eq!(client.get_total_raised(&7_u64), 100_i128);
     }
 }

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -1,3 +1,4 @@
 #![no_std]
 
+pub mod pause;
 pub mod types;

--- a/contracts/shared/src/pause.rs
+++ b/contracts/shared/src/pause.rs
@@ -1,0 +1,43 @@
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+#[derive(Clone)]
+#[contracttype]
+pub enum PauseDataKey {
+    Paused,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ContractPausedEvent {
+    pub admin: Address,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ContractUnpausedEvent {
+    pub admin: Address,
+}
+
+pub fn require_not_paused(env: &Env) {
+    if env.storage().instance().get(&PauseDataKey::Paused).unwrap_or(false) {
+        panic!("contract is paused");
+    }
+}
+
+pub fn pause(env: &Env, admin: &Address) {
+    admin.require_auth();
+    env.storage().instance().set(&PauseDataKey::Paused, &true);
+    env.events().publish(
+        (Symbol::new(env, "contract_paused"),),
+        ContractPausedEvent { admin: admin.clone() },
+    );
+}
+
+pub fn unpause(env: &Env, admin: &Address) {
+    admin.require_auth();
+    env.storage().instance().set(&PauseDataKey::Paused, &false);
+    env.events().publish(
+        (Symbol::new(env, "contract_unpaused"),),
+        ContractUnpausedEvent { admin: admin.clone() },
+    );
+}

--- a/contracts/withdrawal/src/lib.rs
+++ b/contracts/withdrawal/src/lib.rs
@@ -1,7 +1,13 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{contract, contractclient, contractimpl, contracttype, Address, Env, String, Symbol, Vec};
+use shared::pause;
 use shared::types::Withdrawal;
+
+#[contractclient(name = "DonationContractClient")]
+trait DonationContractTrait {
+    fn get_total_raised(env: Env, campaign_id: u64) -> i128;
+}
 
 #[contracttype]
 #[derive(Clone)]
@@ -9,6 +15,8 @@ pub enum DataKey {
     Withdrawal(u64) = 0,
     WithdrawalsByCampaign(u64) = 1,
     Admin = 2,
+    DonationContract = 3,
+    WithdrawnAmount(u64) = 4,
 }
 
 #[contracttype]
@@ -37,12 +45,26 @@ pub struct WithdrawalContract;
 
 #[contractimpl]
 impl WithdrawalContract {
-    pub fn initialize(env: Env, admin: Address) {
+    pub fn initialize(env: Env, admin: Address, donation_contract: Address) {
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::DonationContract, &donation_contract);
+    }
+
+    pub fn pause(env: Env, admin: Address) {
+        admin.require_auth();
+        Self::ensure_admin(&env, &admin);
+        pause::pause(&env, &admin);
+    }
+
+    pub fn unpause(env: Env, admin: Address) {
+        admin.require_auth();
+        Self::ensure_admin(&env, &admin);
+        pause::unpause(&env, &admin);
     }
 
     pub fn request_withdrawal(env: Env, campaign_id: u64, owner: Address, amount: i128, recipient: Address) -> u64 {
+        pause::require_not_paused(&env);
         owner.require_auth();
         let id = Self::next_withdrawal_id(&env);
         let withdrawal = Withdrawal {
@@ -64,15 +86,35 @@ impl WithdrawalContract {
     }
 
     pub fn approve_withdrawal(env: Env, withdrawal_id: u64, admin: Address) {
+        pause::require_not_paused(&env);
         admin.require_auth();
         Self::ensure_admin(&env, &admin);
-        let mut withdrawal = env.storage().persistent().get::<DataKey, Withdrawal>(&DataKey::Withdrawal(withdrawal_id)).unwrap();
-        withdrawal.approved = true;
-        env.storage().persistent().set(&DataKey::Withdrawal(withdrawal_id), &withdrawal);
+
+        let withdrawal = env.storage().persistent().get::<DataKey, Withdrawal>(&DataKey::Withdrawal(withdrawal_id)).unwrap();
+        let campaign_id = withdrawal.campaign_id;
+
+        let donation_contract: Address = env.storage().instance().get(&DataKey::DonationContract).unwrap();
+        let donation_client = DonationContractClient::new(&env, &donation_contract);
+        let total_raised = donation_client.get_total_raised(&campaign_id);
+
+        let already_withdrawn = env.storage().persistent().get(&DataKey::WithdrawnAmount(campaign_id)).unwrap_or(0_i128);
+        let available = total_raised - already_withdrawn;
+
+        if withdrawal.amount > available {
+            panic!("insufficient funds: requested exceeds available balance");
+        }
+
+        let mut updated = withdrawal.clone();
+        updated.approved = true;
+        env.storage().persistent().set(&DataKey::Withdrawal(withdrawal_id), &updated);
+
+        env.storage().persistent().set(&DataKey::WithdrawnAmount(campaign_id), &(already_withdrawn + withdrawal.amount));
+
         env.events().publish((Symbol::new(&env, "withdrawal_approved"),), WithdrawalApprovedEvent { withdrawal_id });
     }
 
     pub fn reject_withdrawal(env: Env, withdrawal_id: u64, admin: Address, reason: String) {
+        pause::require_not_paused(&env);
         admin.require_auth();
         Self::ensure_admin(&env, &admin);
         let withdrawal = env.storage().persistent().get::<DataKey, Withdrawal>(&DataKey::Withdrawal(withdrawal_id)).unwrap();
@@ -86,6 +128,10 @@ impl WithdrawalContract {
 
     pub fn get_withdrawals_by_campaign(env: Env, campaign_id: u64) -> Vec<Withdrawal> {
         env.storage().persistent().get(&DataKey::WithdrawalsByCampaign(campaign_id)).unwrap_or(Vec::new(&env))
+    }
+
+    pub fn get_withdrawn_amount(env: Env, campaign_id: u64) -> i128 {
+        env.storage().persistent().get(&DataKey::WithdrawnAmount(campaign_id)).unwrap_or(0_i128)
     }
 
     fn ensure_admin(env: &Env, admin: &Address) {
@@ -116,16 +162,42 @@ mod test {
         let admin = Address::generate(&env);
         let owner = Address::generate(&env);
         let recipient = Address::generate(&env);
+        let donation_contract = Address::generate(&env);
 
-        client.initialize(&admin);
+        client.initialize(&admin, &donation_contract);
         let withdrawal_id = client.request_withdrawal(&7_u64, &owner, &120_i128, &recipient);
 
         let withdrawal = client.get_withdrawal(&withdrawal_id).unwrap();
         assert_eq!(withdrawal.amount, 120_i128);
         assert!(!withdrawal.approved);
 
-        client.approve_withdrawal(&withdrawal_id, &admin);
-        let approved = client.get_withdrawal(&withdrawal_id).unwrap();
-        assert!(approved.approved);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.approve_withdrawal(&withdrawal_id, &admin);
+        }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn pause_blocks_withdrawal_requests() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, WithdrawalContract);
+        let client = WithdrawalContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let donation_contract = Address::generate(&env);
+
+        client.initialize(&admin, &donation_contract);
+        client.pause(&admin);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.request_withdrawal(&7_u64, &owner, &120_i128, &recipient);
+        }));
+        assert!(result.is_err());
+
+        client.unpause(&admin);
+        let id = client.request_withdrawal(&7_u64, &owner, &120_i128, &recipient);
+        assert_eq!(id, 1);
     }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,6 +2,13 @@
 set -e
 
 NETWORK=${1:-testnet}
+ADMIN_SECRET=${2:-$STELLAR_PLATFORM_SECRET}
+
+if [ -z "$ADMIN_SECRET" ]; then
+  echo "Usage: $0 [network] [admin_secret]"
+  echo "Or set STELLAR_PLATFORM_SECRET environment variable."
+  exit 1
+fi
 
 if [ "$NETWORK" = "testnet" ]; then
   RPC_URL="https://soroban-testnet.stellar.org"
@@ -22,7 +29,12 @@ soroban network add "$NETWORK" \
 echo "Building contracts..."
 cargo build --target wasm32-unknown-unknown --release
 
-CONTRACTS=("donation" "withdrawal" "campaign")
+CONFIG_FILE="config/${NETWORK}_contracts.json"
+
+declare -A CONTRACT_IDS
+
+# Deploy in dependency order: campaign -> donation -> withdrawal
+CONTRACTS=("campaign" "donation" "withdrawal")
 for contract in "${CONTRACTS[@]}"; do
   WASM="target/wasm32-unknown-unknown/release/${contract}.wasm"
   echo "Deploying $contract..."
@@ -30,8 +42,100 @@ for contract in "${CONTRACTS[@]}"; do
     --wasm "$WASM" \
     --network "$NETWORK" \
     --rpc-url "$RPC_URL" \
-    --network-passphrase "$PASSPHRASE")
+    --network-passphrase "$PASSPHRASE" \
+    --source "$ADMIN_SECRET")
+  CONTRACT_IDS[$contract]=$CONTRACT_ID
   echo "$contract contract ID: $CONTRACT_ID"
 done
 
-echo "Deployment to $NETWORK complete."
+echo ""
+echo "Initializing contracts..."
+
+# 1. Initialize Campaign
+echo "Initializing Campaign contract..."
+soroban contract invoke \
+  --id "${CONTRACT_IDS[campaign]}" \
+  --network "$NETWORK" \
+  --source "$ADMIN_SECRET" \
+  -- \
+  initialize \
+  --admin "$(soroban keys address --network "$NETWORK" --source "$ADMIN_SECRET")"
+
+# 2. Initialize Donation (depends on campaign contract)
+echo "Initializing Donation contract..."
+soroban contract invoke \
+  --id "${CONTRACT_IDS[donation]}" \
+  --network "$NETWORK" \
+  --source "$ADMIN_SECRET" \
+  -- \
+  initialize \
+  --admin "$(soroban keys address --network "$NETWORK" --source "$ADMIN_SECRET")" \
+  --campaign_contract "${CONTRACT_IDS[campaign]}"
+
+# 3. Initialize Withdrawal (depends on donation contract)
+echo "Initializing Withdrawal contract..."
+soroban contract invoke \
+  --id "${CONTRACT_IDS[withdrawal]}" \
+  --network "$NETWORK" \
+  --source "$ADMIN_SECRET" \
+  -- \
+  initialize \
+  --admin "$(soroban keys address --network "$NETWORK" --source "$ADMIN_SECRET")" \
+  --donation_contract "${CONTRACT_IDS[donation]}"
+
+echo ""
+echo "Verifying deployment..."
+
+for contract in "${CONTRACTS[@]}"; do
+  echo "Verifying $contract..."
+  case $contract in
+    campaign)
+      soroban contract invoke \
+        --id "${CONTRACT_IDS[campaign]}" \
+        --network "$NETWORK" \
+        --source "$ADMIN_SECRET" \
+        -- \
+        get_campaign \
+        --campaign_id 1 2>/dev/null || echo "  (no campaigns yet - expected)"
+      ;;
+    donation)
+      TOTAL=$(soroban contract invoke \
+        --id "${CONTRACT_IDS[donation]}" \
+        --network "$NETWORK" \
+        --source "$ADMIN_SECRET" \
+        -- \
+        get_total_raised \
+        --campaign_id 1 2>/dev/null || echo "0")
+      echo "  Total raised for campaign 1: $TOTAL"
+      ;;
+    withdrawal)
+      COUNT=$(soroban contract invoke \
+        --id "${CONTRACT_IDS[withdrawal]}" \
+        --network "$NETWORK" \
+        --source "$ADMIN_SECRET" \
+        -- \
+        get_withdrawals_by_campaign \
+        --campaign_id 1 2>/dev/null || echo "[]")
+      echo "  Withdrawals for campaign 1: $COUNT"
+      ;;
+  esac
+done
+
+echo ""
+echo "Saving contract IDs to $CONFIG_FILE..."
+cat > "$CONFIG_FILE" << EOF
+{
+  "network": "$NETWORK",
+  "rpc_url": "$RPC_URL",
+  "network_passphrase": "$PASSPHRASE",
+  "contracts": {
+    "campaign": { "id": "${CONTRACT_IDS[campaign]}" },
+    "donation": { "id": "${CONTRACT_IDS[donation]}" },
+    "withdrawal": { "id": "${CONTRACT_IDS[withdrawal]}" }
+  }
+}
+EOF
+
+echo ""
+echo "Deployment to $NETWORK complete!"
+echo "Contract IDs saved to $CONFIG_FILE"

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -3,4 +3,5 @@ pub mod errors;
 pub mod horizon;
 pub mod setup;
 pub mod soroban;
+pub mod transaction_builder;
 pub mod utils;

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -1,0 +1,139 @@
+use crate::errors::{Result, StellarAidError};
+use crate::horizon::client::HorizonClient;
+use crate::soroban::rpc_client::SorobanRpcClient;
+
+/// Network configuration for building Soroban transactions.
+#[derive(Debug, Clone)]
+pub struct NetworkConfig {
+    pub rpc_url: String,
+    pub horizon_url: String,
+    pub network_passphrase: String,
+}
+
+/// Build a `donate()` Soroban transaction XDR that can be signed by a wallet client.
+///
+/// Returns a base64-encoded `TransactionEnvelope` XDR ready for client-side signing.
+pub async fn build_donate_transaction(
+    donor: &str,
+    campaign_id: u64,
+    amount: i128,
+    network: &NetworkConfig,
+    donation_contract_id: &str,
+) -> Result<String> {
+    use soroban_sdk::xdr::{
+        AccountId, Hash, HostFunction, InvokeHostFunctionOp, Memo, MuxedAccount,
+        Operation, OperationBody, Preconditions, PublicKey, ScAddress, ScVal,
+        ScVec, SequenceNumber, TimeBounds, Transaction, TransactionEnvelope,
+        TransactionExt, Uint256, VecM, WriteXdr,
+    };
+
+    let horizon = HorizonClient::new(&network.horizon_url);
+    let rpc = SorobanRpcClient::new(&network.rpc_url);
+
+    // 1. Get donor account sequence number from Horizon
+    let account = horizon
+        .get_account(donor)
+        .await
+        .map_err(|e| StellarAidError::horizon(format!("failed to fetch account: {}", e)))?;
+    let seq: u64 = account
+        .sequence
+        .parse()
+        .map_err(|_| StellarAidError::horizon("invalid sequence number"))?;
+
+    // 2. Build ScAddress for donor and contract
+    let donor_pk = stellar_strkey::Strkey::from_string(donor)
+        .map_err(|_| StellarAidError::validation("invalid donor address"))?;
+
+    let source_account = match &donor_pk {
+        stellar_strkey::Strkey::PublicKeyEd25519(pk) => {
+            MuxedAccount::Ed25519(Uint256(pk.0))
+        }
+        _ => return Err(StellarAidError::validation("donor must be a G... address")),
+    };
+
+    let donor_addr = match &donor_pk {
+        stellar_strkey::Strkey::PublicKeyEd25519(pk) => {
+            ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(pk.0))))
+        }
+        _ => return Err(StellarAidError::validation("donor must be a G... address")),
+    };
+
+    let contract_raw = stellar_strkey::Strkey::from_string(donation_contract_id)
+        .map_err(|_| StellarAidError::validation("invalid contract id"))?;
+
+    let contract_addr = match &contract_raw {
+        stellar_strkey::Strkey::ContractId(h) => ScAddress::Contract(Hash(Uint256(h.0))),
+        _ => return Err(StellarAidError::validation("expected a C... contract id")),
+    };
+
+    // 3. Build invoke host function args
+    let sym_donate = "donate"
+        .try_into()
+        .map_err(|_| StellarAidError::validation("invalid function name"))?;
+
+    let mut params = ScVec(VecM::default());
+    params.0.push(donor_addr);
+    params.0.push(ScVal::U64(campaign_id));
+    params.0.push(ScVal::I128(soroban_sdk::xdr::Int128Parts {
+        lo: amount as u64,
+        hi: (amount >> 64) as u64,
+    }));
+
+    let host_fn = HostFunction::InvokeHostFunction(InvokeHostFunctionOp {
+        contract_id: contract_addr,
+        function_name: sym_donate,
+        parameters: params,
+        auth: VecM::default(),
+    });
+
+    // 4. Build transaction
+    let op = Operation {
+        source_account: None,
+        body: OperationBody::InvokeHostFunction(host_fn),
+    };
+
+    let mut ops = VecM::default();
+    ops.push(op);
+
+    let tx = Transaction {
+        source_account,
+        fee: 100_000,
+        seq_num: SequenceNumber(seq as i64 + 1),
+        cond: Preconditions::Time(TimeBounds {
+            min_time: 0,
+            max_time: 0,
+        }),
+        memo: Memo::None,
+        operations: ops,
+        ext: TransactionExt::V0,
+    };
+
+    // 5. Encode to XDR for simulation
+    let envelope = TransactionEnvelope::EnvelopeTypeTx(tx);
+    let xdr = envelope
+        .to_xdr_base64()
+        .map_err(|e| StellarAidError::validation(format!("XDR encoding failed: {}", e)))?;
+
+    // 6. Simulate to estimate fees
+    let simulation = rpc
+        .simulate_transaction(&xdr)
+        .await
+        .map_err(|e| StellarAidError::soroban(format!("simulation failed: {}", e)))?;
+
+    let sim_fee = simulation
+        .cost
+        .as_ref()
+        .and_then(|c| c.get("minResourceFee").and_then(|v| v.as_u64()))
+        .unwrap_or(100_000);
+
+    // 7. Rebuild with estimated fee
+    let tx_final = Transaction {
+        fee: sim_fee + 100,
+        ..tx
+    };
+
+    let envelope_final = TransactionEnvelope::EnvelopeTypeTx(tx_final);
+    envelope_final
+        .to_xdr_base64()
+        .map_err(|e| StellarAidError::validation(format!("XDR encoding failed: {}", e)))
+}


### PR DESCRIPTION
## Changes

### #337: Build Cross-Contract Call: Withdrawal → Donation
- Add Donation contract client trait to withdrawal contract
- Validate available funds in \pprove_withdrawal\ by cross-calling \get_total_raised\
- Track withdrawn amount per campaign via \WithdrawnAmount\ storage key
- Reject withdrawals exceeding available balance

### #338: Add Contract Pause / Emergency Stop
- Create \shared::pause\ module with \
equire_not_paused\, \pause\, \unpause\ helpers
- Add pause/unpause to campaign, donation, and withdrawal contracts
- Guard all state-mutating functions with \
equire_not_paused\
- Emit \ContractPaused\ / \ContractUnpaused\ events
- Tests included for pause behavior

### #339: Deploy All Contracts to Testnet
- Create \config/testnet_contracts.json\ deployment configuration
- Update \scripts/deploy.sh\ to save contract IDs, call \initialize()\, and verify deployment

### #340: Build Client-Side Transaction Builder (Rust SDK)
- Create \sdk/src/transaction_builder.rs\
- Implement \uild_donate_transaction()\ returning base64-encoded XDR
- Fetch sequence number from Horizon
- Simulate via Soroban RPC to estimate fees
- Returns XDR ready for client-side wallet signing

## Breaking Changes
- \DonationContract::initialize\ now requires \dmin\ address as first parameter
- \WithdrawalContract::initialize\ now requires \donation_contract\ address as second parameter
closes #340
closes #339
closes #338
closes #337