### PR TITLE
Feat: Donation refund, submission endpoint, custom token & anonymous support

### DIFF
--- a/contracts/donation/src/lib.rs
+++ b/contracts/donation/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractclient, contractimpl, contracttype, Address, BytesN, Env, Symbol, Vec};
-use shared::types::{Campaign, CampaignStatus, Donation};
+use soroban_sdk::{contract, contractclient, contractimpl, contracttype, Address, BytesN, Env, String, Symbol, Vec};
+use shared::types::{Campaign, CampaignStatus, Donation, DonationRefundedEvent, AnonymousDonationEvent};
 use shared::pause;
-use shared::types::Donation;
 
 #[contractclient(name = "CampaignContractClient")]
 trait CampaignContractTrait {
@@ -28,15 +27,6 @@ pub struct DonationMadeEvent {
     pub donor: Address,
     pub campaign_id: u64,
     pub amount: i128,
-}
-
-#[contracttype]
-#[derive(Clone)]
-pub struct RefundRecordedEvent {
-    pub campaign_id: u64,
-    pub donor: Address,
-    pub amount: i128,
-    pub caller: Address,
 }
 
 #[contract]
@@ -66,9 +56,19 @@ impl DonationContract {
         pause::unpause(&env, &admin);
     }
 
-    pub fn donate(env: Env, donor: Address, campaign_id: u64, amount: i128) {
+    pub fn donate(
+        env: Env,
+        donor: Address,
+        campaign_id: u64,
+        amount: i128,
+        token_address: Option<Address>,
+        anonymous: bool,
+        memo: Option<String>,
+    ) {
         pause::require_not_paused(&env);
-        donor.require_auth();
+        if !anonymous {
+            donor.require_auth();
+        }
         if amount <= 0 {
             panic!("amount must be positive");
         }
@@ -80,32 +80,56 @@ impl DonationContract {
             panic!("campaign is not active");
         }
 
-        let mut donations = env.storage().persistent().get(&DataKey::CampaignDonations(campaign_id)).unwrap_or(Vec::new(&env));
+        let effective_donor = if anonymous {
+            Address::generate(&env)
+        } else {
+            donor.clone()
+        };
+
         let timestamp = env.ledger().timestamp();
         let donation = Donation {
-            donor: donor.clone(),
+            donor: effective_donor.clone(),
             campaign_id,
             amount,
             timestamp,
+            memo: memo.clone(),
+            anonymous,
+            token_address: token_address.clone(),
         };
+
+        let mut donations = env.storage().persistent().get(&DataKey::CampaignDonations(campaign_id)).unwrap_or(Vec::new(&env));
         donations.push_back(donation.clone());
         env.storage().persistent().set(&DataKey::CampaignDonations(campaign_id), &donations);
 
-        let donor_history = env.storage().persistent().get(&DataKey::DonationHistory(donor.clone())).unwrap_or(Vec::new(&env));
-        let mut history = donor_history;
-        history.push_back(donation.clone());
-        env.storage().persistent().set(&DataKey::DonationHistory(donor), &history);
+        if !anonymous {
+            let mut history = env.storage().persistent().get(&DataKey::DonationHistory(donor.clone())).unwrap_or(Vec::new(&env));
+            history.push_back(donation.clone());
+            env.storage().persistent().set(&DataKey::DonationHistory(donor), &history);
+        }
 
         let total = env.storage().persistent().get(&DataKey::CampaignRaised(campaign_id)).unwrap_or(0_i128);
         env.storage().persistent().set(&DataKey::CampaignRaised(campaign_id), &(total + amount));
 
         campaign_client.update_raised(&campaign_id, &amount);
 
-        env.events().publish((Symbol::new(&env, "donation_made"),), DonationMadeEvent {
-            donor: donation.donor,
-            campaign_id,
-            amount,
-        });
+        if anonymous {
+            env.events().publish(
+                (Symbol::new(&env, "anonymous_donation"),),
+                AnonymousDonationEvent {
+                    campaign_id,
+                    amount,
+                },
+            );
+        } else {
+            env.events().publish(
+                (Symbol::new(&env, "donation_made"),),
+                DonationMadeEvent {
+                    donor: effective_donor,
+                    campaign_id,
+                    amount,
+                },
+            );
+        }
     }
 
     pub fn refund(env: Env, caller: Address, campaign_id: u64, donor: Address, amount: i128) {
@@ -114,17 +138,32 @@ impl DonationContract {
         let campaign_contract: Address = env.storage().instance().get(&DataKey::CampaignContract).unwrap();
         let campaign_client = CampaignContractClient::new(&env, &campaign_contract);
         let campaign = campaign_client.get_campaign(&campaign_id).unwrap_or_else(|| panic!("campaign not found"));
+        if campaign.status != CampaignStatus::Rejected {
+            panic!("refund only allowed for rejected campaigns");
+        }
         if caller != admin && caller != campaign.owner {
             panic!("unauthorized");
         }
+
         let total = env.storage().persistent().get(&DataKey::CampaignRaised(campaign_id)).unwrap_or(0_i128);
+        if amount > total {
+            panic!("refund amount exceeds total raised");
+        }
         env.storage().persistent().set(&DataKey::CampaignRaised(campaign_id), &(total - amount));
-        env.events().publish((Symbol::new(&env, "refund_recorded"),), RefundRecordedEvent {
-            campaign_id,
-            donor,
-            amount,
-            caller,
-        });
+
+        let mut donations: Vec<Donation> = env.storage().persistent().get(&DataKey::CampaignDonations(campaign_id)).unwrap_or(Vec::new(&env));
+        let filtered: Vec<Donation> = donations.iter().filter(|d| d.donor != donor || d.amount != amount).collect();
+        env.storage().persistent().set(&DataKey::CampaignDonations(campaign_id), &filtered);
+
+        env.events().publish(
+            (Symbol::new(&env, "donation_refunded"),),
+            DonationRefundedEvent {
+                campaign_id,
+                donor,
+                amount,
+                caller,
+            },
+        );
     }
 
     pub fn get_donations_for_campaign(env: Env, campaign_id: u64) -> Vec<Donation> {
@@ -150,6 +189,127 @@ impl DonationContract {
         if stored_admin != *admin {
             panic!("unauthorized");
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    #[test]
+    fn donation_flow_records_history_and_total() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+        let donor = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let campaign_contract = Address::generate(&env);
+
+        client.initialize(&admin, &campaign_contract);
+        client.donate(&donor, &7_u64, &100_i128, &None, &false, &None);
+
+        let donations = client.get_donations_for_campaign(&7_u64);
+        assert_eq!(donations.len(), 1);
+        assert_eq!(client.get_total_raised(&7_u64), 100_i128);
+    }
+
+    #[test]
+    fn pause_blocks_donations() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+        let donor = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let campaign_contract = Address::generate(&env);
+
+        client.initialize(&admin, &campaign_contract);
+        client.pause(&admin);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.donate(&donor, &7_u64, &100_i128, &None, &false, &None);
+        }));
+        assert!(result.is_err());
+
+        client.unpause(&admin);
+        client.donate(&donor, &7_u64, &100_i128, &None, &false, &None);
+        assert_eq!(client.get_total_raised(&7_u64), 100_i128);
+    }
+
+    #[test]
+    fn anonymous_donation_does_not_track_donor() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+        let donor = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let campaign_contract = Address::generate(&env);
+
+        client.initialize(&admin, &campaign_contract);
+        client.donate(&donor, &7_u64, &100_i128, &None, &true, &None);
+
+        let history = client.get_donor_history(&donor);
+        assert_eq!(history.len(), 0);
+
+        let donations = client.get_donations_for_campaign(&7_u64);
+        assert_eq!(donations.len(), 1);
+    }
+
+    #[test]
+    fn refund_only_for_rejected_campaign() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+        let donor = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let campaign_contract = Address::generate(&env);
+
+        client.initialize(&admin, &campaign_contract);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.refund(&admin, &7_u64, &donor, &100_i128);
+        }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn donation_with_token_address() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+        let donor = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let campaign_contract = Address::generate(&env);
+        let token = Address::generate(&env);
+
+        client.initialize(&admin, &campaign_contract);
+        client.donate(&donor, &7_u64, &100_i128, &Some(token), &false, &None);
+
+        let donations = client.get_donations_for_campaign(&7_u64);
+        assert_eq!(donations.len(), 1);
+        assert_eq!(donations.get(0).unwrap().token_address, Some(token));
+    }
+
+    #[test]
+    fn donation_with_memo() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, DonationContract);
+        let client = DonationContractClient::new(&env, &contract_id);
+        let donor = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let campaign_contract = Address::generate(&env);
+        let memo = String::from_str(&env, "Happy Birthday!");
+
+        client.initialize(&admin, &campaign_contract);
+        client.donate(&donor, &7_u64, &100_i128, &None, &false, &Some(memo.clone()));
+
+        let donations = client.get_donations_for_campaign(&7_u64);
+        assert_eq!(donations.get(0).unwrap().memo, Some(memo));
     }
 }
 

--- a/contracts/shared/src/types.rs
+++ b/contracts/shared/src/types.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, String};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -20,6 +20,9 @@ pub struct Donation {
     pub campaign_id: u64,
     pub amount: i128,
     pub timestamp: u64,
+    pub memo: Option<String>,
+    pub anonymous: bool,
+    pub token_address: Option<Address>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -38,4 +41,20 @@ pub enum CampaignStatus {
     Completed = 1,
     Suspended = 2,
     Rejected = 3,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct DonationRefundedEvent {
+    pub campaign_id: u64,
+    pub donor: Address,
+    pub amount: i128,
+    pub caller: Address,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct AnonymousDonationEvent {
+    pub campaign_id: u64,
+    pub amount: i128,
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod errors;
 pub mod horizon;
 pub mod logging;
+pub mod retry;
 pub mod setup;
 pub mod soroban;
 pub mod transaction_builder;

--- a/sdk/src/retry.rs
+++ b/sdk/src/retry.rs
@@ -1,0 +1,134 @@
+use tokio::time::{sleep, Duration};
+use tracing::warn;
+
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    pub max_attempts: u32,
+    pub base_delay_ms: u64,
+    pub max_delay_ms: u64,
+    pub backoff_factor: f64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 5,
+            base_delay_ms: 200,
+            max_delay_ms: 10_000,
+            backoff_factor: 2.0,
+        }
+    }
+}
+
+pub async fn retry_async<F, Fut, T, E>(config: &RetryConfig, f: F) -> Result<T, E>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    let mut attempt = 0u32;
+    loop {
+        attempt += 1;
+        match f().await {
+            Ok(val) => return Ok(val),
+            Err(e) => {
+                if attempt >= config.max_attempts {
+                    return Err(e);
+                }
+                let delay = calculate_delay(config, attempt);
+                warn!(
+                    attempt = attempt,
+                    max_attempts = config.max_attempts,
+                    delay_ms = delay,
+                    "retryable operation failed, retrying"
+                );
+                sleep(Duration::from_millis(delay)).await;
+            }
+        }
+    }
+}
+
+fn calculate_delay(config: &RetryConfig, attempt: u32) -> u64 {
+    let delay = config.base_delay_ms as f64 * config.backoff_factor.powi(attempt as i32 - 1);
+    (delay as u64).min(config.max_delay_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[tokio::test]
+    async fn retry_succeeds_on_first_attempt() {
+        let config = RetryConfig {
+            max_attempts: 3,
+            ..Default::default()
+        };
+        let result = retry_async(&config, || async { Ok::<_, &str>(42) }).await;
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn retry_succeeds_after_failures() {
+        let config = RetryConfig {
+            max_attempts: 5,
+            base_delay_ms: 10,
+            ..Default::default()
+        };
+        let counter = AtomicU32::new(0);
+        let result = retry_async(&config, || async {
+            let count = counter.fetch_add(1, Ordering::SeqCst);
+            if count < 2 {
+                Err::<&str, &str>("not yet")
+            } else {
+                Ok("finally")
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), "finally");
+    }
+
+    #[tokio::test]
+    async fn retry_exhausts_attempts() {
+        let config = RetryConfig {
+            max_attempts: 3,
+            base_delay_ms: 10,
+            ..Default::default()
+        };
+        let counter = AtomicU32::new(0);
+        let result = retry_async(&config, || async {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Err::<&str, &str>("always fails")
+        })
+        .await;
+        assert_eq!(result.unwrap_err(), "always fails");
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn delay_calculation_backs_off() {
+        let config = RetryConfig {
+            base_delay_ms: 100,
+            max_delay_ms: 10_000,
+            backoff_factor: 2.0,
+            ..Default::default()
+        };
+        assert_eq!(calculate_delay(&config, 1), 100);
+        assert_eq!(calculate_delay(&config, 2), 200);
+        assert_eq!(calculate_delay(&config, 3), 400);
+        assert_eq!(calculate_delay(&config, 4), 800);
+    }
+
+    #[test]
+    fn delay_capped_at_max() {
+        let config = RetryConfig {
+            base_delay_ms: 1000,
+            max_delay_ms: 2500,
+            backoff_factor: 2.0,
+            ..Default::default()
+        };
+        assert_eq!(calculate_delay(&config, 1), 1000);
+        assert_eq!(calculate_delay(&config, 2), 2000);
+        assert_eq!(calculate_delay(&config, 3), 2500);
+        assert_eq!(calculate_delay(&config, 4), 2500);
+    }
+}

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -2,7 +2,6 @@ use crate::errors::{Result, StellarAidError};
 use crate::horizon::client::HorizonClient;
 use crate::soroban::rpc_client::SorobanRpcClient;
 
-/// Network configuration for building Soroban transactions.
 #[derive(Debug, Clone)]
 pub struct NetworkConfig {
     pub rpc_url: String,
@@ -10,15 +9,39 @@ pub struct NetworkConfig {
     pub network_passphrase: String,
 }
 
-/// Build a `donate()` Soroban transaction XDR that can be signed by a wallet client.
-///
-/// Returns a base64-encoded `TransactionEnvelope` XDR ready for client-side signing.
+#[derive(Debug, Clone)]
+pub struct DonationParams {
+    pub donor: String,
+    pub campaign_id: u64,
+    pub amount: i128,
+    pub token_address: Option<String>,
+    pub anonymous: bool,
+    pub memo: Option<String>,
+    pub donation_contract_id: String,
+}
+
 pub async fn build_donate_transaction(
     donor: &str,
     campaign_id: u64,
     amount: i128,
     network: &NetworkConfig,
     donation_contract_id: &str,
+) -> Result<String> {
+    let params = DonationParams {
+        donor: donor.to_string(),
+        campaign_id,
+        amount,
+        token_address: None,
+        anonymous: false,
+        memo: None,
+        donation_contract_id: donation_contract_id.to_string(),
+    };
+    build_donate_transaction_full(&params, network).await
+}
+
+pub async fn build_donate_transaction_full(
+    params: &DonationParams,
+    network: &NetworkConfig,
 ) -> Result<String> {
     use soroban_sdk::xdr::{
         AccountId, Hash, HostFunction, InvokeHostFunctionOp, Memo, MuxedAccount,
@@ -30,9 +53,8 @@ pub async fn build_donate_transaction(
     let horizon = HorizonClient::new(&network.horizon_url);
     let rpc = SorobanRpcClient::new(&network.rpc_url);
 
-    // 1. Get donor account sequence number from Horizon
     let account = horizon
-        .get_account(donor)
+        .get_account(&params.donor)
         .await
         .map_err(|e| StellarAidError::horizon(format!("failed to fetch account: {}", e)))?;
     let seq: u64 = account
@@ -40,8 +62,7 @@ pub async fn build_donate_transaction(
         .parse()
         .map_err(|_| StellarAidError::horizon("invalid sequence number"))?;
 
-    // 2. Build ScAddress for donor and contract
-    let donor_pk = stellar_strkey::Strkey::from_string(donor)
+    let donor_pk = stellar_strkey::Strkey::from_string(&params.donor)
         .map_err(|_| StellarAidError::validation("invalid donor address"))?;
 
     let source_account = match &donor_pk {
@@ -58,7 +79,7 @@ pub async fn build_donate_transaction(
         _ => return Err(StellarAidError::validation("donor must be a G... address")),
     };
 
-    let contract_raw = stellar_strkey::Strkey::from_string(donation_contract_id)
+    let contract_raw = stellar_strkey::Strkey::from_string(&params.donation_contract_id)
         .map_err(|_| StellarAidError::validation("invalid contract id"))?;
 
     let contract_addr = match &contract_raw {
@@ -66,27 +87,54 @@ pub async fn build_donate_transaction(
         _ => return Err(StellarAidError::validation("expected a C... contract id")),
     };
 
-    // 3. Build invoke host function args
     let sym_donate = "donate"
         .try_into()
         .map_err(|_| StellarAidError::validation("invalid function name"))?;
 
-    let mut params = ScVec(VecM::default());
-    params.0.push(donor_addr);
-    params.0.push(ScVal::U64(campaign_id));
-    params.0.push(ScVal::I128(soroban_sdk::xdr::Int128Parts {
-        lo: amount as u64,
-        hi: (amount >> 64) as u64,
+    let mut params_sc = ScVec(VecM::default());
+    params_sc.0.push(donor_addr);
+    params_sc.0.push(ScVal::U64(params.campaign_id));
+    params_sc.0.push(ScVal::I128(soroban_sdk::xdr::Int128Parts {
+        lo: params.amount as u64,
+        hi: (params.amount >> 64) as u64,
     }));
+
+    let token_val = match &params.token_address {
+        Some(addr) => {
+            let raw = stellar_strkey::Strkey::from_string(addr)
+                .map_err(|_| StellarAidError::validation("invalid token address"))?;
+            match &raw {
+                stellar_strkey::Strkey::ContractId(h) => {
+                    ScVal::Address(ScAddress::Contract(Hash(Uint256(h.0))))
+                }
+                _ => return Err(StellarAidError::validation("expected a C... contract id for token")),
+            }
+        }
+        None => ScVal::Address(ScAddress::Contract(Hash(Uint256([0u8; 32])))),
+    };
+    params_sc.0.push(token_val);
+
+    params_sc.0.push(ScVal::Bool(params.anonymous));
+
+    let memo_val = match &params.memo {
+        Some(m) => {
+            let mut chars = VecM::default();
+            for b in m.bytes() {
+                chars.push(b as i64);
+            }
+            ScVal::Vec(Some(ScVec(chars)))
+        }
+        None => ScVal::Void,
+    };
+    params_sc.0.push(memo_val);
 
     let host_fn = HostFunction::InvokeHostFunction(InvokeHostFunctionOp {
         contract_id: contract_addr,
         function_name: sym_donate,
-        parameters: params,
+        parameters: params_sc,
         auth: VecM::default(),
     });
 
-    // 4. Build transaction
     let op = Operation {
         source_account: None,
         body: OperationBody::InvokeHostFunction(host_fn),
@@ -94,6 +142,17 @@ pub async fn build_donate_transaction(
 
     let mut ops = VecM::default();
     ops.push(op);
+
+    let memo_xdr = match &params.memo {
+        Some(m) => {
+            let mut bytes = VecM::default();
+            for b in m.bytes() {
+                bytes.push(b);
+            }
+            Memo::MemoText(bytes)
+        }
+        None => Memo::None,
+    };
 
     let tx = Transaction {
         source_account,
@@ -103,18 +162,16 @@ pub async fn build_donate_transaction(
             min_time: 0,
             max_time: 0,
         }),
-        memo: Memo::None,
+        memo: memo_xdr,
         operations: ops,
         ext: TransactionExt::V0,
     };
 
-    // 5. Encode to XDR for simulation
     let envelope = TransactionEnvelope::EnvelopeTypeTx(tx);
     let xdr = envelope
         .to_xdr_base64()
         .map_err(|e| StellarAidError::validation(format!("XDR encoding failed: {}", e)))?;
 
-    // 6. Simulate to estimate fees
     let simulation = rpc
         .simulate_transaction(&xdr)
         .await
@@ -126,7 +183,6 @@ pub async fn build_donate_transaction(
         .and_then(|c| c.get("minResourceFee").and_then(|v| v.as_u64()))
         .unwrap_or(100_000);
 
-    // 7. Rebuild with estimated fee
     let tx_final = Transaction {
         fee: sim_fee + 100,
         ..tx

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -17,4 +17,6 @@ dotenvy = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+axum = { version = "0.7", features = ["macros"] }
+tower-http = { version = "0.5", features = ["cors", "trace"] }
 sdk = { path = "../sdk" }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -1,6 +1,188 @@
-use sdk::logging;
+mod webhooks;
 
-fn main() {
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::Json,
+    routing::{get, post},
+    Router,
+};
+use sdk::{
+    errors::StellarAidError,
+    logging,
+    retry::{retry_async, RetryConfig},
+    soroban::rpc_client::SorobanRpcClient,
+    transaction_builder::{build_donate_transaction_full, DonationParams, NetworkConfig},
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::info;
+use webhooks::{WebhookManager, WebhookPayload};
+
+#[derive(Debug, Deserialize)]
+pub struct SubmitDonationRequest {
+    pub donor: String,
+    pub campaign_id: u64,
+    pub amount: i128,
+    pub token_address: Option<String>,
+    pub anonymous: Option<bool>,
+    pub memo: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SubmitDonationResponse {
+    pub xdr: String,
+    pub donation_contract_id: String,
+    pub network_passphrase: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DonationInfo {
+    pub tx_hash: String,
+    pub donor: String,
+    pub campaign_id: u64,
+    pub amount: i128,
+    pub status: String,
+    pub memo: Option<String>,
+    pub anonymous: bool,
+    pub token_address: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
+#[derive(Clone)]
+pub struct AppState {
+    pub network_config: NetworkConfig,
+    pub donation_contract_id: String,
+    pub webhook_manager: WebhookManager,
+}
+
+async fn submit_donation(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<SubmitDonationRequest>,
+) -> Result<Json<SubmitDonationResponse>, (StatusCode, Json<ErrorResponse>)> {
+    if req.amount <= 0 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "amount must be positive".to_string(),
+            }),
+        ));
+    }
+
+    let params = DonationParams {
+        donor: req.donor,
+        campaign_id: req.campaign_id,
+        amount: req.amount,
+        token_address: req.token_address,
+        anonymous: req.anonymous.unwrap_or(false),
+        memo: req.memo,
+        donation_contract_id: state.donation_contract_id.clone(),
+    };
+
+    let retry_config = RetryConfig::default();
+    let network = state.network_config.clone();
+
+    let xdr = retry_async(&retry_config, || async {
+        build_donate_transaction_full(&params, &network)
+            .await
+            .map_err(|e| StellarAidError::SorobanError(e.to_string()))
+    })
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("transaction build failed: {}", e),
+            }),
+        )
+    })?;
+
+    Ok(Json(SubmitDonationResponse {
+        xdr,
+        donation_contract_id: state.donation_contract_id.clone(),
+        network_passphrase: state.network_config.network_passphrase.clone(),
+    }))
+}
+
+async fn get_donation(
+    State(state): State<Arc<AppState>>,
+    Path(tx_hash): Path<String>,
+) -> Result<Json<DonationInfo>, (StatusCode, Json<ErrorResponse>)> {
+    let rpc = SorobanRpcClient::new(&state.network_config.rpc_url);
+
+    let status = retry_async(&RetryConfig::default(), || async {
+        rpc.get_transaction_status(&tx_hash)
+            .await
+            .map_err(|e| StellarAidError::SorobanError(e.to_string()))
+    })
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("failed to get transaction status: {}", e),
+            }),
+        )
+    })?;
+
+    let status_str = match status {
+        sdk::soroban::rpc_client::TransactionStatus::Pending => "pending".to_string(),
+        sdk::soroban::rpc_client::TransactionStatus::Success => "success".to_string(),
+        sdk::soroban::rpc_client::TransactionStatus::Failed => "failed".to_string(),
+        sdk::soroban::rpc_client::TransactionStatus::NotFound => "not_found".to_string(),
+    };
+
+    Ok(Json(DonationInfo {
+        tx_hash: tx_hash.clone(),
+        donor: String::new(),
+        campaign_id: 0,
+        amount: 0,
+        status: status_str,
+        memo: None,
+        anonymous: false,
+        token_address: None,
+    }))
+}
+
+async fn health() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "status": "ok" }))
+}
+
+#[tokio::main]
+async fn main() {
     let _ = logging::init_logging();
-    tracing::info!(event = "worker_startup", "StellarAid worker starting");
+    info!(event = "worker_startup", "StellarAid worker starting");
+
+    let network_config = NetworkConfig {
+        rpc_url: std::env::var("SOROBAN_RPC_URL")
+            .unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string()),
+        horizon_url: std::env::var("HORIZON_URL")
+            .unwrap_or_else(|_| "https://horizon-testnet.stellar.org".to_string()),
+        network_passphrase: std::env::var("SOROBAN_NETWORK_PASSPHRASE")
+            .unwrap_or_else(|_| "Test SDF Network ; September 2015".to_string()),
+    };
+
+    let donation_contract_id =
+        std::env::var("DONATION_CONTRACT_ID").unwrap_or_else(|_| String::new());
+
+    let state = Arc::new(AppState {
+        network_config,
+        donation_contract_id,
+        webhook_manager: WebhookManager::new(),
+    });
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/api/donations/submit", post(submit_donation))
+        .route("/api/donations/{tx_hash}", get(get_donation))
+        .with_state(state);
+
+    let bind = std::env::var("BIND_ADDRESS").unwrap_or_else(|_| "0.0.0.0:3000".to_string());
+    info!(bind = %bind, "listening");
+    let listener = tokio::net::TcpListener::bind(&bind).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }

--- a/worker/src/webhooks.rs
+++ b/worker/src/webhooks.rs
@@ -1,0 +1,89 @@
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{error, info, warn};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookConfig {
+    pub url: String,
+    pub secret: Option<String>,
+    pub events: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookPayload {
+    pub event: String,
+    pub campaign_id: u64,
+    pub donor: String,
+    pub amount: String,
+    pub tx_hash: String,
+    pub timestamp: u64,
+}
+
+type WebhookStore = Arc<RwLock<HashMap<String, Vec<WebhookConfig>>>>;
+
+#[derive(Clone)]
+pub struct WebhookManager {
+    client: Client,
+    store: WebhookStore,
+}
+
+impl WebhookManager {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+            store: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn register(&self, campaign_id: u64, config: WebhookConfig) {
+        let key = campaign_id.to_string();
+        let mut store = self.store.write().await;
+        store.entry(key).or_default().push(config);
+        info!(campaign_id = campaign_id, "webhook registered");
+    }
+
+    pub async fn dispatch(&self, campaign_id: u64, payload: WebhookPayload) {
+        let key = campaign_id.to_string();
+        let configs = {
+            let store = self.store.read().await;
+            store.get(&key).cloned().unwrap_or_default()
+        };
+
+        for config in &configs {
+            if !config.events.is_empty() && !config.events.contains(&payload.event) {
+                continue;
+            }
+
+            let mut req = self.client.post(&config.url).json(&payload);
+            if let Some(secret) = &config.secret {
+                req = req.header("X-Webhook-Secret", secret);
+            }
+
+            match req.send().await {
+                Ok(resp) => {
+                    if resp.status().is_success() {
+                        info!(url = %config.url, event = %payload.event, "webhook delivered");
+                    } else {
+                        warn!(
+                            url = %config.url,
+                            status = %resp.status(),
+                            "webhook delivery returned non-success"
+                        );
+                    }
+                }
+                Err(e) => {
+                    error!(url = %config.url, error = %e, "webhook delivery failed");
+                }
+            }
+        }
+    }
+}
+
+impl Default for WebhookManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Changes

### Donation Refund (#353)
- Improved refund function now requires campaign to be in Rejected status
- Removes refunded donation from campaign donation list
- Validates refund amount does not exceed total raised

### Donation Submission Endpoint (#351)
- Added POST /api/donations/submit endpoint to the Rust HTTP worker
- Builds Soroban transaction XDR with retry logic
- Returns XDR, contract ID, and network passphrase for client signing

### Custom Soroban Token Support (#350)
- Extended donate() to accept optional token_address parameter
- Supports non-XLM Soroban token contracts
- Token address stored in donation record

### Anonymous Donation Support (#349)
- Added optional anonymous flag to donate()
- Anonymous donations use a generated address as donor
- Donor history is not recorded for anonymous donations
- Publishes AnonymousDonationEvent instead of DonationMadeEvent

### Additional
- Memo field support in donation struct and contract
- Retry utility with exponential backoff in SDK
- Webhook manager for donation confirmation events
- GET /api/donations/:tx_hash endpoint for transaction status

Closes #353
Closes #351 
Closes #350 
Closes #349