### PR TITLE
unified wallet implementation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm install *)",
+      "Bash(npx tsc *)",
+      "Bash(git -C /home/feyishola/Desktop/mydev/opensource/stellarAid-contract status)",
+      "Bash(xargs cat)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 .env
 *.wasm
+node_modules/
+package-lock.json

--- a/docs/wallets/FREIGHTER.md
+++ b/docs/wallets/FREIGHTER.md
@@ -1,0 +1,261 @@
+# Freighter Wallet Integration Guide
+
+[Freighter](https://www.freighter.app/) is a non-custodial browser extension wallet for the Stellar network.
+
+---
+
+## Installation
+
+```bash
+npm install @stellar/freighter-api
+```
+
+The `@stellaraid/wallets` SDK package already lists this as a dependency, so if
+you consume the SDK you do **not** need to install it separately.
+
+---
+
+## Quick Start
+
+```ts
+import {
+  isFreighterInstalled,
+  connectFreighter,
+  signTransactionWithFreighter,
+  FreighterNotInstalledError,
+  NETWORK_PASSPHRASE,
+} from "@stellaraid/wallets";
+
+// 1. Gate your UI
+if (!isFreighterInstalled()) {
+  showInstallBanner("https://www.freighter.app/");
+}
+
+// 2. Connect
+const publicKey = await connectFreighter();
+console.log("Connected:", publicKey); // G…
+
+// 3. Sign a transaction
+const signedXdr = await signTransactionWithFreighter(
+  unsignedXdr,
+  NETWORK_PASSPHRASE.TESTNET
+);
+```
+
+---
+
+## API Reference
+
+### `isFreighterInstalled(): boolean`
+
+Synchronous check. Returns `true` when the Freighter extension is detectable in
+the current browser environment.
+
+```ts
+if (!isFreighterInstalled()) {
+  // prompt the user to install Freighter
+}
+```
+
+> **Note:** Use this to conditionally render a "Connect Freighter" button. For
+> authoritative runtime errors (e.g. the user locked the extension between
+> page load and the click), rely on the errors thrown by `connectFreighter()`.
+
+---
+
+### `connectFreighter(): Promise<string>`
+
+Requests access to the user's Stellar account via Freighter. Opens the Freighter
+popup on first call; subsequent calls return immediately if the site is already
+trusted. Returns the user's public key (`G…`).
+
+```ts
+try {
+  const publicKey = await connectFreighter();
+  // store publicKey in your app state
+} catch (err) {
+  if (err instanceof FreighterNotInstalledError) {
+    window.open(err.downloadUrl, "_blank");
+  } else {
+    console.error("Connection failed:", err.message);
+  }
+}
+```
+
+**Throws:**
+- `FreighterNotInstalledError` — extension is not present in the browser.
+- `Error` — user rejected the connection, or Freighter is locked.
+
+---
+
+### `signTransactionWithFreighter(xdr: string, network: string): Promise<string>`
+
+Signs a base64-encoded XDR transaction envelope. Opens the Freighter popup
+for user approval. Returns the signed XDR string.
+
+| Parameter | Type     | Description                                    |
+|-----------|----------|------------------------------------------------|
+| `xdr`     | `string` | Base64-encoded unsigned transaction envelope.  |
+| `network` | `string` | Network passphrase (see constants below).      |
+
+```ts
+import { NETWORK_PASSPHRASE, signTransactionWithFreighter } from "@stellaraid/wallets";
+import { TransactionBuilder, Networks, Operation, Asset } from "@stellar/stellar-sdk";
+
+const tx = new TransactionBuilder(sourceAccount, {
+  fee: "100",
+  networkPassphrase: NETWORK_PASSPHRASE.TESTNET,
+})
+  .addOperation(/* … */)
+  .setTimeout(30)
+  .build();
+
+try {
+  const signedXdr = await signTransactionWithFreighter(
+    tx.toXDR(),
+    NETWORK_PASSPHRASE.TESTNET
+  );
+  // submit signedXdr to Horizon / Soroban RPC
+} catch (err) {
+  if (err instanceof FreighterNotInstalledError) {
+    window.open(err.downloadUrl, "_blank");
+  } else {
+    console.error("Signing rejected:", err.message);
+  }
+}
+```
+
+**Throws:**
+- `FreighterNotInstalledError` — extension is not present in the browser.
+- `Error` — user rejected signing or Freighter reported an internal error.
+
+---
+
+### `NETWORK_PASSPHRASE`
+
+```ts
+export const NETWORK_PASSPHRASE = {
+  MAINNET: "Public Global Stellar Network ; September 2015",
+  TESTNET: "Test SDF Network ; September 2015",
+} as const;
+```
+
+Pass the appropriate constant as the `network` argument to
+`signTransactionWithFreighter`.
+
+---
+
+### `FreighterNotInstalledError`
+
+Extends the built-in `Error`. Carries a `downloadUrl` property pointing to
+`https://www.freighter.app/` so callers can open the install page directly.
+
+```ts
+catch (err) {
+  if (err instanceof FreighterNotInstalledError) {
+    window.open(err.downloadUrl, "_blank");
+  }
+}
+```
+
+---
+
+## Error Handling Patterns
+
+### Show a download banner
+
+```ts
+import { isFreighterInstalled, FREIGHTER_DOWNLOAD_URL } from "@stellaraid/wallets";
+
+function WalletConnectButton() {
+  if (!isFreighterInstalled()) {
+    return (
+      <a href={FREIGHTER_DOWNLOAD_URL} target="_blank" rel="noreferrer">
+        Install Freighter to continue
+      </a>
+    );
+  }
+  return <button onClick={handleConnect}>Connect Freighter</button>;
+}
+```
+
+### Distinguish rejection from missing extension
+
+```ts
+import { connectFreighter, FreighterNotInstalledError } from "@stellaraid/wallets";
+
+async function handleConnect() {
+  try {
+    const key = await connectFreighter();
+    setPublicKey(key);
+  } catch (err) {
+    if (err instanceof FreighterNotInstalledError) {
+      setError("Please install the Freighter extension.");
+      window.open(err.downloadUrl, "_blank");
+    } else {
+      setError("Connection was cancelled or Freighter is locked.");
+    }
+  }
+}
+```
+
+---
+
+## End-to-End Example: Donate via StellarAid
+
+```ts
+import {
+  connectFreighter,
+  signTransactionWithFreighter,
+  NETWORK_PASSPHRASE,
+} from "@stellaraid/wallets";
+import { Server, TransactionBuilder, Networks, Operation, Asset } from "@stellar/stellar-sdk";
+
+const HORIZON_URL = "https://horizon-testnet.stellar.org";
+const DONATION_CONTRACT = "<campaign-contract-id>";
+
+async function donate(amountXlm: string) {
+  // 1. Connect wallet
+  const publicKey = await connectFreighter();
+
+  // 2. Build transaction
+  const server = new Server(HORIZON_URL);
+  const account = await server.loadAccount(publicKey);
+  const tx = new TransactionBuilder(account, {
+    fee: "1000",
+    networkPassphrase: NETWORK_PASSPHRASE.TESTNET,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: DONATION_CONTRACT,
+        asset: Asset.native(),
+        amount: amountXlm,
+      })
+    )
+    .setTimeout(60)
+    .build();
+
+  // 3. Sign
+  const signedXdr = await signTransactionWithFreighter(
+    tx.toXDR(),
+    NETWORK_PASSPHRASE.TESTNET
+  );
+
+  // 4. Submit
+  const result = await server.submitTransaction(
+    TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE.TESTNET)
+  );
+  console.log("Transaction hash:", result.hash);
+}
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `FreighterNotInstalledError` | Extension not installed or not enabled for this origin | Direct user to `https://www.freighter.app/` |
+| "Freighter access denied" | User clicked Reject in the popup | Ask the user to try again and click Accept |
+| `signTransaction` fails with no error | Extension is locked | Ask the user to unlock Freighter and retry |
+| `isFreighterInstalled()` returns `false` in a test environment | `window` or `window.freighter` is not defined | Mock `window.freighter` in your test setup |

--- a/sdk/bindings/package.json
+++ b/sdk/bindings/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@stellaraid/wallet-adapters",
+  "version": "0.1.0",
+  "description": "Unified wallet adapter interface for Freighter, Albedo, and Lobstr",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@lobstrco/signer-extension-api": "^0.1.0",
+    "@stellar/freighter-api": "^1.7.1",
+    "albedo-link": "^0.2.3"
+  },
+  "peerDependenciesMeta": {
+    "@stellar/freighter-api": {
+      "optional": true
+    },
+    "albedo-link": {
+      "optional": true
+    },
+    "@lobstrco/signer-extension-api": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/sdk/bindings/src/index.ts
+++ b/sdk/bindings/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./wallet";

--- a/sdk/bindings/src/wallet/albedo.ts
+++ b/sdk/bindings/src/wallet/albedo.ts
@@ -1,0 +1,63 @@
+import type { WalletAdapter } from "./types";
+
+// Minimal subset of the albedo-link API surface.
+interface AlbedoLib {
+  publicKey(params?: { token?: string }): Promise<{ pubkey: string }>;
+  tx(params: {
+    xdr: string;
+    network?: string;
+    submit?: boolean;
+  }): Promise<{ signed_envelope_xdr: string }>;
+}
+
+declare const window: Window & { albedo?: AlbedoLib };
+
+// albedo-link is also available as an ES module default export.
+let _albedo: AlbedoLib | undefined;
+
+async function getAlbedo(): Promise<AlbedoLib> {
+  if (_albedo) return _albedo;
+  if (typeof window !== "undefined" && window.albedo) {
+    _albedo = window.albedo;
+    return _albedo;
+  }
+  try {
+    // Indirect specifier prevents TypeScript from statically resolving the
+    // optional peer dependency, which may not be installed in all environments.
+    const specifier = "albedo-link";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = await (Function("s", "return import(s)")(specifier) as Promise<any>);
+    _albedo = (mod.default ?? mod) as AlbedoLib;
+    return _albedo;
+  } catch {
+    throw new Error("albedo-link is not installed. Run: npm install albedo-link");
+  }
+}
+
+export class AlbedoAdapter implements WalletAdapter {
+  readonly name = "Albedo";
+
+  private _publicKey: string | null = null;
+
+  isAvailable(): boolean {
+    // Albedo works via a popup — no extension required. Always available in a browser.
+    return typeof window !== "undefined";
+  }
+
+  async connect(): Promise<string> {
+    const albedo = await getAlbedo();
+    const { pubkey } = await albedo.publicKey();
+    this._publicKey = pubkey;
+    return pubkey;
+  }
+
+  async sign(xdr: string): Promise<string> {
+    const albedo = await getAlbedo();
+    const { signed_envelope_xdr } = await albedo.tx({ xdr, submit: false });
+    return signed_envelope_xdr;
+  }
+
+  disconnect(): void {
+    this._publicKey = null;
+  }
+}

--- a/sdk/bindings/src/wallet/freighter.ts
+++ b/sdk/bindings/src/wallet/freighter.ts
@@ -1,0 +1,49 @@
+import type { WalletAdapter } from "./types";
+
+// Minimal subset of @stellar/freighter-api that we depend on.
+interface FreighterApi {
+  isConnected(): Promise<{ isConnected: boolean }>;
+  getAddress(): Promise<{ address: string }>;
+  signTransaction(
+    xdr: string,
+    opts?: { networkPassphrase?: string }
+  ): Promise<{ signedTxXdr: string }>;
+}
+
+declare const window: Window & {
+  freighter?: FreighterApi;
+};
+
+export class FreighterAdapter implements WalletAdapter {
+  readonly name = "Freighter";
+
+  isAvailable(): boolean {
+    return typeof window !== "undefined" && window.freighter !== undefined;
+  }
+
+  async connect(): Promise<string> {
+    const api = this.api();
+    const { isConnected } = await api.isConnected();
+    if (!isConnected) {
+      throw new Error("Freighter is not connected. Open the extension and unlock it.");
+    }
+    const { address } = await api.getAddress();
+    return address;
+  }
+
+  async sign(xdr: string): Promise<string> {
+    const { signedTxXdr } = await this.api().signTransaction(xdr);
+    return signedTxXdr;
+  }
+
+  disconnect(): void {
+    // Freighter manages its own session; nothing to clear on our side.
+  }
+
+  private api(): FreighterApi {
+    if (!this.isAvailable()) {
+      throw new Error("Freighter extension is not installed or not available.");
+    }
+    return window.freighter!;
+  }
+}

--- a/sdk/bindings/src/wallet/index.ts
+++ b/sdk/bindings/src/wallet/index.ts
@@ -1,0 +1,9 @@
+export type { WalletAdapter } from "./types";
+export { FreighterAdapter } from "./freighter";
+export { AlbedoAdapter } from "./albedo";
+export { LobstrAdapter } from "./lobstr";
+export {
+  WalletAdapterRegistry,
+  getDefaultAdapter,
+  getAdapterByName,
+} from "./registry";

--- a/sdk/bindings/src/wallet/lobstr.ts
+++ b/sdk/bindings/src/wallet/lobstr.ts
@@ -1,0 +1,47 @@
+import type { WalletAdapter } from "./types";
+
+// Minimal subset of @lobstrco/signer-extension-api.
+interface LobstrExtension {
+  isConnected(): Promise<boolean>;
+  getPublicKey(): Promise<string>;
+  signTransaction(xdr: string): Promise<string>;
+}
+
+declare const window: Window & {
+  lobstrExtension?: LobstrExtension;
+};
+
+export class LobstrAdapter implements WalletAdapter {
+  readonly name = "Lobstr";
+
+  isAvailable(): boolean {
+    return (
+      typeof window !== "undefined" &&
+      window.lobstrExtension !== undefined
+    );
+  }
+
+  async connect(): Promise<string> {
+    const ext = this.extension();
+    const connected = await ext.isConnected();
+    if (!connected) {
+      throw new Error("Lobstr Signer extension is not connected. Open the extension and unlock it.");
+    }
+    return ext.getPublicKey();
+  }
+
+  async sign(xdr: string): Promise<string> {
+    return this.extension().signTransaction(xdr);
+  }
+
+  disconnect(): void {
+    // The Lobstr extension manages its own session state.
+  }
+
+  private extension(): LobstrExtension {
+    if (!this.isAvailable()) {
+      throw new Error("Lobstr Signer extension is not installed or not available.");
+    }
+    return window.lobstrExtension!;
+  }
+}

--- a/sdk/bindings/src/wallet/registry.ts
+++ b/sdk/bindings/src/wallet/registry.ts
@@ -1,0 +1,34 @@
+import type { WalletAdapter } from "./types";
+import { FreighterAdapter } from "./freighter";
+import { AlbedoAdapter } from "./albedo";
+import { LobstrAdapter } from "./lobstr";
+
+/**
+ * All supported wallet adapters.
+ * Switching the active wallet requires no code change — pick any entry
+ * that satisfies `adapter.isAvailable()`.
+ */
+export const WalletAdapterRegistry: readonly WalletAdapter[] = [
+  new FreighterAdapter(),
+  new AlbedoAdapter(),
+  new LobstrAdapter(),
+] as const;
+
+/**
+ * Return the first adapter that reports itself as available, or null if none
+ * are detectable in the current environment.
+ */
+export function getDefaultAdapter(): WalletAdapter | null {
+  return WalletAdapterRegistry.find((a) => a.isAvailable()) ?? null;
+}
+
+/**
+ * Look up an adapter by its display name (case-insensitive).
+ */
+export function getAdapterByName(name: string): WalletAdapter | null {
+  return (
+    WalletAdapterRegistry.find(
+      (a) => a.name.toLowerCase() === name.toLowerCase()
+    ) ?? null
+  );
+}

--- a/sdk/bindings/src/wallet/types.ts
+++ b/sdk/bindings/src/wallet/types.ts
@@ -1,0 +1,25 @@
+export interface WalletAdapter {
+  /** Human-readable wallet name. */
+  readonly name: string;
+
+  /**
+   * Connect to the wallet and return the user's public key.
+   * Throws if the user rejects the connection or the wallet is unavailable.
+   */
+  connect(): Promise<string>;
+
+  /**
+   * Sign a base64-encoded XDR transaction envelope and return the signed XDR.
+   * Throws if the user rejects the signing request.
+   */
+  sign(xdr: string): Promise<string>;
+
+  /** Disconnect / clear any session state held by the adapter. */
+  disconnect(): void;
+
+  /**
+   * Return true when the wallet extension or service is detectable in the
+   * current environment. Does not guarantee the user is connected.
+   */
+  isAvailable(): boolean;
+}

--- a/sdk/bindings/tsconfig.json
+++ b/sdk/bindings/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/sdk/wallets/freighter.ts
+++ b/sdk/wallets/freighter.ts
@@ -1,0 +1,110 @@
+import {
+  isBrowser,
+  isConnected,
+  requestAccess,
+  signTransaction,
+} from "@stellar/freighter-api";
+
+export const FREIGHTER_DOWNLOAD_URL = "https://www.freighter.app/";
+
+export const NETWORK_PASSPHRASE = {
+  MAINNET: "Public Global Stellar Network ; September 2015",
+  TESTNET: "Test SDF Network ; September 2015",
+} as const;
+
+export type StellarNetwork = (typeof NETWORK_PASSPHRASE)[keyof typeof NETWORK_PASSPHRASE];
+
+/** Thrown when Freighter extension is not present in the browser. */
+export class FreighterNotInstalledError extends Error {
+  readonly downloadUrl = FREIGHTER_DOWNLOAD_URL;
+
+  constructor() {
+    super(
+      `Freighter wallet extension is not installed. ` +
+        `Download it at ${FREIGHTER_DOWNLOAD_URL}`
+    );
+    this.name = "FreighterNotInstalledError";
+  }
+}
+
+/**
+ * Return true when the Freighter extension is detectable in the current
+ * environment. Synchronous — no network or extension round-trip.
+ *
+ * Note: use this to gate UI (e.g. show a "Connect Freighter" button only when
+ * true). For the authoritative check before signing, rely on the errors thrown
+ * by connectFreighter() and signTransactionWithFreighter().
+ */
+export function isFreighterInstalled(): boolean {
+  return isBrowser && "freighter" in window;
+}
+
+/**
+ * Ask Freighter to expose the user's public key to this page.
+ * Opens the Freighter popup for approval on first call; subsequent calls
+ * return immediately if the site is already trusted.
+ *
+ * @returns The connected Stellar public key (G…).
+ * @throws {FreighterNotInstalledError} when the extension is absent.
+ * @throws {Error} when the user rejects the connection request.
+ */
+export async function connectFreighter(): Promise<string> {
+  if (!isFreighterInstalled()) {
+    throw new FreighterNotInstalledError();
+  }
+
+  const connectionCheck = await isConnected();
+  if (connectionCheck.error) {
+    throw new Error(
+      `Freighter connection check failed: ${connectionCheck.error.message}`
+    );
+  }
+
+  // requestAccess opens the Freighter popup and returns the public key once
+  // the user grants permission (or immediately if already allowed).
+  const { address, error } = await requestAccess();
+  if (error) {
+    throw new Error(`Freighter access denied: ${error.message}`);
+  }
+  if (!address) {
+    throw new Error(
+      "Freighter did not return a public key. Make sure the extension is unlocked."
+    );
+  }
+
+  return address;
+}
+
+/**
+ * Sign a base64-encoded XDR transaction envelope with Freighter.
+ *
+ * @param xdr     - Base64-encoded XDR of the unsigned transaction envelope.
+ * @param network - Network passphrase. Use NETWORK_PASSPHRASE.TESTNET or
+ *                  NETWORK_PASSPHRASE.MAINNET, or a custom passphrase string.
+ * @returns Signed XDR envelope as a base64 string.
+ * @throws {FreighterNotInstalledError} when the extension is absent.
+ * @throws {Error} when the user rejects signing or Freighter reports an error.
+ */
+export async function signTransactionWithFreighter(
+  xdr: string,
+  network: string
+): Promise<string> {
+  if (!isFreighterInstalled()) {
+    throw new FreighterNotInstalledError();
+  }
+
+  const { signedTxXdr, error } = await signTransaction(xdr, {
+    networkPassphrase: network,
+  });
+
+  if (error) {
+    throw new Error(`Freighter signing failed: ${error.message}`);
+  }
+  if (!signedTxXdr) {
+    throw new Error(
+      "Freighter did not return signed XDR. The request may have been rejected."
+    );
+  }
+
+  return signedTxXdr;
+}

--- a/sdk/wallets/index.ts
+++ b/sdk/wallets/index.ts
@@ -1,0 +1,9 @@
+export {
+  isFreighterInstalled,
+  connectFreighter,
+  signTransactionWithFreighter,
+  FreighterNotInstalledError,
+  FREIGHTER_DOWNLOAD_URL,
+  NETWORK_PASSPHRASE,
+} from "./freighter";
+export type { StellarNetwork } from "./freighter";

--- a/sdk/wallets/package.json
+++ b/sdk/wallets/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@stellaraid/wallets",
+  "version": "0.1.0",
+  "description": "Wallet helpers for StellarAid — Freighter, Albedo, Lobstr",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@stellar/freighter-api": "^3.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  },
+  "files": ["dist"]
+}

--- a/sdk/wallets/tsconfig.json
+++ b/sdk/wallets/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["freighter.ts", "index.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
closes #365 
closes #357 
closes #358 
closes #359 

Implementation Summary
1. Unified Wallet Adapter Interface (sdk/bindings/)
Purpose: A single abstract interface so any wallet can be swapped in without touching the rest of the codebase.

Files created:

File	Role
src/wallet/types.ts	Core WalletAdapter interface
src/wallet/freighter.ts	FreighterAdapter class
src/wallet/albedo.ts	AlbedoAdapter class
src/wallet/lobstr.ts	LobstrAdapter class
src/wallet/registry.ts	WalletAdapterRegistry + helpers
src/wallet/index.ts	Barrel export
package.json	@stellaraid/wallet-adapters package
tsconfig.json	TypeScript config
The interface every adapter satisfies:


interface WalletAdapter {
  name: string
  connect(): Promise<string>       // returns public key
  sign(xdr: string): Promise<string>
  disconnect(): void
  isAvailable(): boolean
}
How each adapter detects availability:

Adapter	Detection mechanism
FreighterAdapter	window.freighter !== undefined
AlbedoAdapter	Any browser (window exists) — popup-based, no extension needed
LobstrAdapter	window.lobstrExtension !== undefined
Registry — how you use it:


// Get all adapters
WalletAdapterRegistry  // readonly WalletAdapter[]

// Pick the first available one automatically
getDefaultAdapter()    // WalletAdapter | null

// Pick by name
getAdapterByName("Lobstr")  // WalletAdapter | null
Switching wallets is one line — every adapter is interchangeable behind the same interface. All three peer deps (@stellar/freighter-api, albedo-link, @lobstrco/signer-extension-api) are optional so consumers only pay for what they use.

2. Freighter Wallet SDK + Docs (sdk/wallets/ + docs/wallets/)
Purpose: A simpler, functional API on top of the real @stellar/freighter-api v3 package, with proper error classes and an integration guide.

Files created:

File	Role
sdk/wallets/freighter.ts	Three standalone functions + error class + constants
sdk/wallets/index.ts	Barrel export
sdk/wallets/package.json	@stellaraid/wallets package, @stellar/freighter-api as real dep
sdk/wallets/tsconfig.json	TypeScript config
docs/wallets/FREIGHTER.md	Full integration guide
Three exported functions:


// Sync — safe to call on render/mount
isFreighterInstalled(): boolean

// Opens Freighter popup; returns G… public key
connectFreighter(): Promise<string>

// Opens Freighter popup for signing; returns signed XDR
signTransactionWithFreighter(xdr: string, network: string): Promise<string>
Error handling design:

FreighterNotInstalledError — typed subclass of Error, carries .downloadUrl = "https://www.freighter.app/" so callers can redirect users to install the extension without hardcoding the URL.
All other failures (user rejection, locked wallet) throw a plain Error with a descriptive message from the Freighter API.
Exported constants:


NETWORK_PASSPHRASE.MAINNET  // "Public Global Stellar Network ; September 2015"
NETWORK_PASSPHRASE.TESTNET  // "Test SDF Network ; September 2015"
The integration guide (docs/wallets/FREIGHTER.md) covers: API reference, error handling patterns, a full donate-via-StellarAid end-to-end example, React UI pattern for showing the install banner, and a troubleshooting table.

Key Design Difference Between the Two
sdk/bindings/ (Adapter)	sdk/wallets/ (Functional)
Style	Class-based, OOP	Standalone functions
Dependency	All wallets as optional peer deps	@stellar/freighter-api as a real dep
Use case	Plug any wallet in at runtime via registry	Direct Freighter-only integration
Relationship	FreighterAdapter wraps window.freighter directly	Uses the official npm SDK with full v3 types
The two layers are complementary — the functional SDK (sdk/wallets/) is what a frontend dev reaches for to get Freighter working quickly, while the adapter registry (sdk/bindings/) is what a multi-wallet UI uses to stay wallet-agnostic.