### PR TITLE
feat(contract): create DisputeArbiter contract with initialize, resolve_for_client, resolve_for_artist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "contracts/shared",
     "contracts/platform_config",
     "contracts/escrow",
+    "contracts/commission_agreement",
 ]
 resolver = "2"
 

--- a/contracts/commission_agreement/src/test.rs
+++ b/contracts/commission_agreement/src/test.rs
@@ -1,0 +1,612 @@
+extern crate std;
+use soroban_sdk::{Env, Bytes, Address, String};
+use crate::CommissionAgreementContract;
+use crate::types::{AgreementStatus, MilestoneStatus};
+use crate::errors::AgreementError;
+
+fn create_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn sample_id(env: &Env) -> Bytes {
+    Bytes::from_array(env, b"commission_001")
+}
+
+fn milestone_id(env: &Env) -> Bytes {
+    Bytes::from_array(env, b"milestone_001")
+}
+
+fn milestone_id_2(env: &Env) -> Bytes {
+    Bytes::from_array(env, b"milestone_002")
+}
+
+fn client(env: &Env) -> Address {
+    Address::generate(env)
+}
+
+fn artist(env: &Env) -> Address {
+    Address::generate(env)
+}
+
+fn title(env: &Env) -> String {
+    String::from_str(env, "Test Commission")
+}
+
+fn ms_title(env: &Env) -> String {
+    String::from_str(env, "Draft Phase")
+}
+
+fn ms_title_2(env: &Env) -> String {
+    String::from_str(env, "Final Phase")
+}
+
+// --- create_agreement ---
+
+#[test]
+fn test_create_agreement_success() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let result = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+    assert!(result.is_ok());
+
+    let record = client.get_agreement(&env, &sample_id(&env)).unwrap();
+    assert_eq!(record.status, AgreementStatus::Pending);
+    assert_eq!(record.budget_usdc, 10000);
+}
+
+#[test]
+fn test_create_agreement_zero_budget() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let result = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &0,
+        &1000,
+    );
+    assert_eq!(result.unwrap_err(), AgreementError::InvalidAmount);
+}
+
+#[test]
+fn test_create_agreement_past_deadline() {
+    let env = create_env();
+    env.ledger().set(500);
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let result = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &400,
+    );
+    assert_eq!(result.unwrap_err(), AgreementError::DeadlineInPast);
+}
+
+#[test]
+fn test_create_agreement_duplicate() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let result = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &5000,
+        &1000,
+    );
+    assert_eq!(result.unwrap_err(), AgreementError::AlreadyExists);
+}
+
+#[test]
+fn test_create_agreement_wrong_auth() {
+    let env = Env::default();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client_contract = CommissionAgreementContract::new(&contract_addr);
+
+    let bad_actor = Address::generate(&env);
+
+    let result = client_contract.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    assert!(result.is_ok());
+}
+
+// --- accept_agreement ---
+
+#[test]
+fn test_accept_agreement_success() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let result = client.accept_agreement(&env, &sample_id(&env));
+    assert!(result.is_ok());
+
+    let record = client.get_agreement(&env, &sample_id(&env)).unwrap();
+    assert_eq!(record.status, AgreementStatus::Active);
+}
+
+#[test]
+fn test_accept_agreement_wrong_status() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let _ = client.accept_agreement(&env, &sample_id(&env));
+
+    let result = client.accept_agreement(&env, &sample_id(&env));
+    assert_eq!(result.unwrap_err(), AgreementError::InvalidStatus);
+}
+
+#[test]
+fn test_accept_agreement_wrong_auth() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client_contract = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client_contract.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let result = client_contract.accept_agreement(&env, &sample_id(&env));
+    assert!(result.is_ok());
+}
+
+// --- reject_agreement ---
+
+#[test]
+fn test_reject_agreement_success() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let result = client.reject_agreement(
+        &env,
+        &sample_id(&env),
+        &String::from_str(&env, "Not interested"),
+    );
+    assert!(result.is_ok());
+
+    let record = client.get_agreement(&env, &sample_id(&env)).unwrap();
+    assert_eq!(record.status, AgreementStatus::Cancelled);
+}
+
+#[test]
+fn test_reject_agreement_wrong_status() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let _ = client.accept_agreement(&env, &sample_id(&env));
+
+    let result = client.reject_agreement(
+        &env,
+        &sample_id(&env),
+        &String::from_str(&env, "Too late"),
+    );
+    assert_eq!(result.unwrap_err(), AgreementError::InvalidStatus);
+}
+
+#[test]
+fn test_reject_agreement_wrong_auth() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let result = client.reject_agreement(
+        &env,
+        &sample_id(&env),
+        &String::from_str(&env, "No"),
+    );
+    assert!(result.is_ok());
+}
+
+// --- propose_milestone ---
+
+#[test]
+fn test_propose_milestone_success() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let _ = client.accept_agreement(&env, &sample_id(&env));
+
+    let result = client.propose_milestone(
+        &env,
+        &sample_id(&env),
+        &milestone_id(&env),
+        &ms_title(&env),
+        &5000,
+    );
+    assert!(result.is_ok());
+
+    let milestones = client.get_milestones(&env, &sample_id(&env)).unwrap();
+    assert_eq!(milestones.len(), 1);
+    assert_eq!(milestones.get(0).unwrap().amount_usdc, 5000);
+    assert_eq!(milestones.get(0).unwrap().status, MilestoneStatus::Pending);
+}
+
+#[test]
+fn test_propose_milestone_exceeds_budget() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let _ = client.accept_agreement(&env, &sample_id(&env));
+
+    let result = client.propose_milestone(
+        &env,
+        &sample_id(&env),
+        &milestone_id(&env),
+        &ms_title(&env),
+        &15000,
+    );
+    assert_eq!(result.unwrap_err(), AgreementError::MilestoneBudgetExceeded);
+}
+
+#[test]
+fn test_propose_milestone_wrong_status() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let result = client.propose_milestone(
+        &env,
+        &sample_id(&env),
+        &milestone_id(&env),
+        &ms_title(&env),
+        &5000,
+    );
+    assert_eq!(result.unwrap_err(), AgreementError::InvalidStatus);
+}
+
+// --- approve_milestone ---
+
+#[test]
+fn test_approve_milestone_success() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let _ = client.accept_agreement(&env, &sample_id(&env));
+
+    let _ = client.propose_milestone(
+        &env,
+        &sample_id(&env),
+        &milestone_id(&env),
+        &ms_title(&env),
+        &5000,
+    );
+
+    let result = client.approve_milestone(&env, &sample_id(&env), &milestone_id(&env));
+    assert!(result.is_ok());
+
+    let milestones = client.get_milestones(&env, &sample_id(&env)).unwrap();
+    assert_eq!(milestones.get(0).unwrap().status, MilestoneStatus::Approved);
+}
+
+#[test]
+fn test_approve_milestone_completes_agreement() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let _ = client.accept_agreement(&env, &sample_id(&env));
+
+    let _ = client.propose_milestone(
+        &env,
+        &sample_id(&env),
+        &milestone_id(&env),
+        &ms_title(&env),
+        &10000,
+    );
+
+    let _ = client.approve_milestone(&env, &sample_id(&env), &milestone_id(&env));
+
+    let record = client.get_agreement(&env, &sample_id(&env)).unwrap();
+    assert_eq!(record.status, AgreementStatus::Completed);
+}
+
+#[test]
+fn test_approve_milestone_wrong_status() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let _ = client.accept_agreement(&env, &sample_id(&env));
+
+    let _ = client.propose_milestone(
+        &env,
+        &sample_id(&env),
+        &milestone_id(&env),
+        &ms_title(&env),
+        &5000,
+    );
+
+    let _ = client.approve_milestone(&env, &sample_id(&env), &milestone_id(&env));
+
+    let result = client.approve_milestone(&env, &sample_id(&env), &milestone_id(&env));
+    assert_eq!(result.unwrap_err(), AgreementError::InvalidStatus);
+}
+
+// --- get_agreement / get_milestones ---
+
+#[test]
+fn test_get_agreement_found() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let result = client.get_agreement(&env, &sample_id(&env));
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().budget_usdc, 10000);
+}
+
+#[test]
+fn test_get_agreement_not_found() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let result = client.get_agreement(&env, &sample_id(&env));
+    assert_eq!(result.unwrap_err(), AgreementError::NotFound);
+}
+
+#[test]
+fn test_get_milestones_found() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let _ = client.accept_agreement(&env, &sample_id(&env));
+
+    let _ = client.propose_milestone(
+        &env,
+        &sample_id(&env),
+        &milestone_id(&env),
+        &ms_title(&env),
+        &3000,
+    );
+
+    let _ = client.propose_milestone(
+        &env,
+        &sample_id(&env),
+        &milestone_id_2(&env),
+        &ms_title_2(&env),
+        &7000,
+    );
+
+    let milestones = client.get_milestones(&env, &sample_id(&env)).unwrap();
+    assert_eq!(milestones.len(), 2);
+    assert_eq!(milestones.get(0).unwrap().amount_usdc, 3000);
+    assert_eq!(milestones.get(1).unwrap().amount_usdc, 7000);
+}
+
+#[test]
+fn test_get_milestones_not_found() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let result = client.get_milestones(&env, &sample_id(&env));
+    assert_eq!(result.unwrap_err(), AgreementError::NotFound);
+}
+
+// --- Multiple milestones partial approval ---
+
+#[test]
+fn test_partial_approval_no_complete() {
+    let env = create_env();
+    let contract_addr = env.register_contract(None, CommissionAgreementContract);
+    let client = CommissionAgreementContract::new(&contract_addr);
+
+    let _ = client.create_agreement(
+        &env,
+        &sample_id(&env),
+        &client(&env),
+        &artist(&env),
+        &title(&env),
+        &10000,
+        &1000,
+    );
+
+    let _ = client.accept_agreement(&env, &sample_id(&env));
+
+    let _ = client.propose_milestone(
+        &env,
+        &sample_id(&env),
+        &milestone_id(&env),
+        &ms_title(&env),
+        &5000,
+    );
+
+    let _ = client.propose_milestone(
+        &env,
+        &sample_id(&env),
+        &milestone_id_2(&env),
+        &ms_title_2(&env),
+        &5000,
+    );
+
+    let _ = client.approve_milestone(&env, &sample_id(&env), &milestone_id(&env));
+
+    let record = client.get_agreement(&env, &sample_id(&env)).unwrap();
+    assert_eq!(record.status, AgreementStatus::Active);
+}

--- a/contracts/dispute_arbiter/Cargo.toml
+++ b/contracts/dispute_arbiter/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "dispute_arbiter"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk.workspace = true
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+default = []
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/dispute_arbiter/src/errors.rs
+++ b/contracts/dispute_arbiter/src/errors.rs
@@ -1,0 +1,43 @@
+use soroban_sdk::{contracterror, symbol_short, Symbol};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum DisputeError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    NotFound = 4,
+    InvalidStatus = 5,
+    AlreadyResolved = 6,
+    AutoResolveNotDue = 7,
+    InvalidShareBps = 8,
+}
+
+impl core::fmt::Display for DisputeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            Self::AlreadyInitialized => write!(f, "already initialized"),
+            Self::NotInitialized => write!(f, "not initialized"),
+            Self::Unauthorized => write!(f, "unauthorized"),
+            Self::NotFound => write!(f, "dispute not found"),
+            Self::InvalidStatus => write!(f, "invalid status"),
+            Self::AlreadyResolved => write!(f, "already resolved"),
+            Self::AutoResolveNotDue => write!(f, "auto-resolve not yet due"),
+            Self::InvalidShareBps => write!(f, "invalid share bps"),
+        }
+    }
+}
+
+pub fn get_suggestion(error: DisputeError) -> Symbol {
+    match error {
+        DisputeError::AlreadyInitialized => symbol_short!("DUP"),
+        DisputeError::NotInitialized => symbol_short!("NO_INIT"),
+        DisputeError::Unauthorized => symbol_short!("AUTH"),
+        DisputeError::NotFound => symbol_short!("NOT_FOUND"),
+        DisputeError::InvalidStatus => symbol_short!("BAD_STS"),
+        DisputeError::AlreadyResolved => symbol_short!("RESOLVED"),
+        DisputeError::AutoResolveNotDue => symbol_short!("NOT_DUE"),
+        DisputeError::InvalidShareBps => symbol_short!("BAD_BPS"),
+    }
+}

--- a/contracts/dispute_arbiter/src/lib.rs
+++ b/contracts/dispute_arbiter/src/lib.rs
@@ -1,0 +1,300 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Bytes, Env, String};
+
+pub mod errors;
+pub mod types;
+
+use errors::DisputeError;
+use types::{DataKey, DisputeRecord, DisputeStatus};
+
+#[contract]
+pub struct DisputeArbiter;
+
+fn has_admin(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Admin)
+}
+
+fn get_admin(env: &Env) -> Result<Address, DisputeError> {
+    if !has_admin(env) {
+        return Err(DisputeError::NotInitialized);
+    }
+    Ok(env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap())
+}
+
+fn get_escrow_contract(env: &Env) -> Result<Address, DisputeError> {
+    if !has_admin(env) {
+        return Err(DisputeError::NotInitialized);
+    }
+    Ok(env
+        .storage()
+        .instance()
+        .get(&DataKey::EscrowContract)
+        .unwrap())
+}
+
+fn get_config_contract(env: &Env) -> Result<Address, DisputeError> {
+    if !has_admin(env) {
+        return Err(DisputeError::NotInitialized);
+    }
+    Ok(env
+        .storage()
+        .instance()
+        .get(&DataKey::ConfigContract)
+        .unwrap())
+}
+
+fn get_auto_resolve_ledgers(env: &Env) -> Result<u32, DisputeError> {
+    if !has_admin(env) {
+        return Err(DisputeError::NotInitialized);
+    }
+    Ok(env
+        .storage()
+        .instance()
+        .get(&DataKey::AutoResolveLedgers)
+        .unwrap())
+}
+
+fn dispute_exists(env: &Env, commission_id: &Bytes) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::Dispute(commission_id.clone()))
+}
+
+fn get_dispute(env: &Env, commission_id: &Bytes) -> Result<DisputeRecord, DisputeError> {
+    if !dispute_exists(env, commission_id) {
+        return Err(DisputeError::NotFound);
+    }
+    Ok(env
+        .storage()
+        .persistent()
+        .get(&DataKey::Dispute(commission_id.clone()))
+        .unwrap())
+}
+
+fn save_dispute(env: &Env, record: &DisputeRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Dispute(record.commission_id.clone()), record);
+}
+
+#[contractimpl]
+impl DisputeArbiter {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        escrow_contract: Address,
+        config_contract: Address,
+        auto_resolve_ledgers: u32,
+    ) -> Result<(), DisputeError> {
+        if has_admin(&env) {
+            return Err(DisputeError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::EscrowContract, &escrow_contract);
+        env.storage()
+            .instance()
+            .set(&DataKey::ConfigContract, &config_contract);
+        env.storage()
+            .instance()
+            .set(&DataKey::AutoResolveLedgers, &auto_resolve_ledgers);
+        env.events()
+            .publish((symbol_short!("init"),), (admin, escrow_contract, config_contract, auto_resolve_ledgers));
+        Ok(())
+    }
+
+    pub fn open_dispute(
+        env: Env,
+        commission_id: Bytes,
+        initiator: Address,
+    ) -> Result<(), DisputeError> {
+        if !has_admin(&env) {
+            return Err(DisputeError::NotInitialized);
+        }
+        initiator.require_auth();
+        if dispute_exists(&env, &commission_id) {
+            return Err(DisputeError::AlreadyResolved);
+        }
+        let current_ledger = env.ledger().sequence();
+        let auto_resolve_offset = get_auto_resolve_ledgers(&env)?;
+        let auto_resolve_ledger = current_ledger + auto_resolve_offset;
+        let record = DisputeRecord {
+            commission_id: commission_id.clone(),
+            opened_ledger: current_ledger,
+            auto_resolve_ledger,
+            status: DisputeStatus::Open,
+            resolution_note: None,
+        };
+        save_dispute(&env, &record);
+        env.events()
+            .publish((symbol_short!("opened"),), (commission_id, initiator, current_ledger, auto_resolve_ledger));
+        Ok(())
+    }
+
+    pub fn resolve_for_client(
+        env: Env,
+        commission_id: Bytes,
+        note: String,
+    ) -> Result<(), DisputeError> {
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+        let mut record = get_dispute(&env, &commission_id)?;
+        if record.status != DisputeStatus::Open {
+            return Err(DisputeError::InvalidStatus);
+        }
+        let escrow_contract = get_escrow_contract(&env)?;
+        let config_contract = get_config_contract(&env)?;
+        env.invoke_contract::<()>(
+            &escrow_contract,
+            &symbol_short!("refund_cl"),
+            soroban_sdk::vec![&env, commission_id.clone().into_val(&env), config_contract.into_val(&env)],
+        );
+        record.status = DisputeStatus::ResolvedForClient;
+        record.resolution_note = Some(note.clone());
+        save_dispute(&env, &record);
+        env.events()
+            .publish((symbol_short!("resolved"),), (commission_id, DisputeStatus::ResolvedForClient, note));
+        Ok(())
+    }
+
+    pub fn resolve_for_artist(
+        env: Env,
+        commission_id: Bytes,
+        note: String,
+    ) -> Result<(), DisputeError> {
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+        let mut record = get_dispute(&env, &commission_id)?;
+        if record.status != DisputeStatus::Open {
+            return Err(DisputeError::InvalidStatus);
+        }
+        let escrow_contract = get_escrow_contract(&env)?;
+        let config_contract = get_config_contract(&env)?;
+        env.invoke_contract::<()>(
+            &escrow_contract,
+            &symbol_short!("release_pa"),
+            soroban_sdk::vec![&env, commission_id.clone().into_val(&env), config_contract.into_val(&env)],
+        );
+        record.status = DisputeStatus::ResolvedForArtist;
+        record.resolution_note = Some(note.clone());
+        save_dispute(&env, &record);
+        env.events()
+            .publish((symbol_short!("resolved"),), (commission_id, DisputeStatus::ResolvedForArtist, note));
+        Ok(())
+    }
+
+    pub fn partial_resolve(
+        env: Env,
+        commission_id: Bytes,
+        client_share_bps: u32,
+        note: String,
+    ) -> Result<(), DisputeError> {
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+        if client_share_bps > 10000 {
+            return Err(DisputeError::InvalidShareBps);
+        }
+        let mut record = get_dispute(&env, &commission_id)?;
+        if record.status != DisputeStatus::Open {
+            return Err(DisputeError::InvalidStatus);
+        }
+        let escrow_contract = get_escrow_contract(&env)?;
+        let config_contract = get_config_contract(&env)?;
+
+        let artist_share_bps = 10000u32
+            .checked_sub(client_share_bps)
+            .ok_or(DisputeError::InvalidShareBps)?;
+
+        env.invoke_contract::<()>(
+            &escrow_contract,
+            &symbol_short!("refund_cl"),
+            soroban_sdk::vec![&env, commission_id.clone().into_val(&env), config_contract.clone().into_val(&env)],
+        );
+
+        let usdc_token: Address = env.invoke_contract(
+            &config_contract,
+            &symbol_short!("get_usdc"),
+            soroban_sdk::vec![&env],
+        );
+        let escrow_balance: i128 = env.invoke_contract(
+            &usdc_token,
+            &symbol_short!("balance"),
+            soroban_sdk::vec![&env, escrow_contract.clone().into_val(&env)],
+        );
+
+        let client_share = escrow_balance * (client_share_bps as i128) / 10000;
+        let artist_share = escrow_balance * (artist_share_bps as i128) / 10000;
+
+        if client_share > 0 {
+            env.invoke_contract::<()>(
+                &usdc_token,
+                &symbol_short!("transfer"),
+                soroban_sdk::vec![
+                    &env,
+                    escrow_contract.clone().into_val(&env),
+                    record.commission_id.clone().into_val(&env),
+                    client_share.into_val(&env),
+                ],
+            );
+        }
+        if artist_share > 0 {
+            env.invoke_contract::<()>(
+                &usdc_token,
+                &symbol_short!("transfer"),
+                soroban_sdk::vec![
+                    &env,
+                    escrow_contract.into_val(&env),
+                    record.commission_id.clone().into_val(&env),
+                    artist_share.into_val(&env),
+                ],
+            );
+        }
+
+        record.status = DisputeStatus::PartiallyResolved;
+        record.resolution_note = Some(note.clone());
+        save_dispute(&env, &record);
+        env.events().publish(
+            (symbol_short!("resolved"),),
+            (commission_id, DisputeStatus::PartiallyResolved, client_share_bps, note),
+        );
+        Ok(())
+    }
+
+    pub fn auto_resolve(env: Env, commission_id: Bytes) -> Result<(), DisputeError> {
+        if !has_admin(&env) {
+            return Err(DisputeError::NotInitialized);
+        }
+        let mut record = get_dispute(&env, &commission_id)?;
+        if record.status != DisputeStatus::Open {
+            return Err(DisputeError::InvalidStatus);
+        }
+        let current_ledger = env.ledger().sequence();
+        if current_ledger < record.auto_resolve_ledger {
+            return Err(DisputeError::AutoResolveNotDue);
+        }
+        let escrow_contract = get_escrow_contract(&env)?;
+        let config_contract = get_config_contract(&env)?;
+        env.invoke_contract::<()>(
+            &escrow_contract,
+            &symbol_short!("refund_cl"),
+            soroban_sdk::vec![&env, commission_id.clone().into_val(&env), config_contract.into_val(&env)],
+        );
+        record.status = DisputeStatus::AutoResolved;
+        save_dispute(&env, &record);
+        env.events()
+            .publish((symbol_short!("auto_res"),), (commission_id, current_ledger));
+        Ok(())
+    }
+
+    pub fn get_dispute(env: Env, commission_id: Bytes) -> Result<DisputeRecord, DisputeError> {
+        get_dispute(&env, &commission_id)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/dispute_arbiter/src/test.rs
+++ b/contracts/dispute_arbiter/src/test.rs
@@ -1,0 +1,126 @@
+extern crate std;
+use soroban_sdk::{testutils::Address as _, Address, Bytes, Env, String};
+use crate::{DisputeArbiterContract, DisputeArbiterContractClient};
+use crate::errors::DisputeError;
+use crate::types::DisputeStatus;
+
+fn setup() -> (Env, Address, Address, Address, DisputeArbiterContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let escrow = Address::generate(&env);
+    let config = Address::generate(&env);
+    let contract_id = env.register_contract(None, DisputeArbiterContract);
+    let client = DisputeArbiterContractClient::new(&env, &contract_id);
+    (env, admin, escrow, config, client)
+}
+
+#[test]
+fn test_initialize_succeeds() {
+    let (env, admin, escrow, config, client) = setup();
+    let result = client.initialize(&admin, &escrow, &config, &100);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_double_initialize_fails() {
+    let (env, admin, escrow, config, client) = setup();
+    let _ = client.initialize(&admin, &escrow, &config, &100);
+    let result = client.initialize(&admin, &escrow, &config, &100);
+    assert_eq!(result, Err(DisputeError::AlreadyInitialized));
+}
+
+#[test]
+fn test_open_dispute_before_init_fails() {
+    let (env, admin, escrow, config, client) = setup();
+    let initiator = Address::generate(&env);
+    let commission_id = Bytes::from_array(&env, &[1, 2, 3]);
+    let result = client.open_dispute(&commission_id, &initiator);
+    assert_eq!(result, Err(DisputeError::NotInitialized));
+}
+
+#[test]
+fn test_open_dispute_succeeds() {
+    let (env, admin, escrow, config, client) = setup();
+    let _ = client.initialize(&admin, &escrow, &config, &100);
+    let initiator = Address::generate(&env);
+    let commission_id = Bytes::from_array(&env, &[1, 2, 3]);
+    let result = client.open_dispute(&commission_id, &initiator);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_open_dispute_duplicate_fails() {
+    let (env, admin, escrow, config, client) = setup();
+    let _ = client.initialize(&admin, &escrow, &config, &100);
+    let initiator = Address::generate(&env);
+    let commission_id = Bytes::from_array(&env, &[1, 2, 3]);
+    let _ = client.open_dispute(&commission_id, &initiator);
+    let result = client.open_dispute(&commission_id, &initiator);
+    assert_eq!(result, Err(DisputeError::AlreadyResolved));
+}
+
+#[test]
+fn test_resolve_for_client_not_found() {
+    let (env, admin, escrow, config, client) = setup();
+    let _ = client.initialize(&admin, &escrow, &config, &100);
+    let commission_id = Bytes::from_array(&env, &[1, 2, 3]);
+    let note = String::from_str(&env, "test note");
+    let result = client.resolve_for_client(&commission_id, &note);
+    assert_eq!(result, Err(DisputeError::NotFound));
+}
+
+#[test]
+fn test_resolve_for_client_succeeds() {
+    let (env, admin, escrow, config, client) = setup();
+    let _ = client.initialize(&admin, &escrow, &config, &100);
+    let initiator = Address::generate(&env);
+    let commission_id = Bytes::from_array(&env, &[1, 2, 3]);
+    let _ = client.open_dispute(&commission_id, &initiator);
+    let note = String::from_str(&env, "refund approved");
+    let result = client.try_resolve_for_client(&commission_id, &note);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_resolve_for_artist_not_found() {
+    let (env, admin, escrow, config, client) = setup();
+    let _ = client.initialize(&admin, &escrow, &config, &100);
+    let commission_id = Bytes::from_array(&env, &[1, 2, 3]);
+    let note = String::from_str(&env, "test note");
+    let result = client.resolve_for_artist(&commission_id, &note);
+    assert_eq!(result, Err(DisputeError::NotFound));
+}
+
+#[test]
+fn test_resolve_for_artist_succeeds() {
+    let (env, admin, escrow, config, client) = setup();
+    let _ = client.initialize(&admin, &escrow, &config, &100);
+    let initiator = Address::generate(&env);
+    let commission_id = Bytes::from_array(&env, &[1, 2, 3]);
+    let _ = client.open_dispute(&commission_id, &initiator);
+    let note = String::from_str(&env, "payment released");
+    let result = client.try_resolve_for_artist(&commission_id, &note);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_get_dispute_not_found() {
+    let (env, admin, escrow, config, client) = setup();
+    let _ = client.initialize(&admin, &escrow, &config, &100);
+    let commission_id = Bytes::from_array(&env, &[1, 2, 3]);
+    let result = client.get_dispute(&commission_id);
+    assert_eq!(result, Err(DisputeError::NotFound));
+}
+
+#[test]
+fn test_dispute_error_codes() {
+    assert_eq!(DisputeError::AlreadyInitialized as u32, 1);
+    assert_eq!(DisputeError::NotInitialized as u32, 2);
+    assert_eq!(DisputeError::Unauthorized as u32, 3);
+    assert_eq!(DisputeError::NotFound as u32, 4);
+    assert_eq!(DisputeError::InvalidStatus as u32, 5);
+    assert_eq!(DisputeError::AlreadyResolved as u32, 6);
+    assert_eq!(DisputeError::AutoResolveNotDue as u32, 7);
+    assert_eq!(DisputeError::InvalidShareBps as u32, 8);
+}

--- a/contracts/dispute_arbiter/src/types.rs
+++ b/contracts/dispute_arbiter/src/types.rs
@@ -1,0 +1,30 @@
+use soroban_sdk::{contracttype, Address, Bytes, String};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeStatus {
+    Open = 0,
+    ResolvedForClient = 1,
+    ResolvedForArtist = 2,
+    PartiallyResolved = 3,
+    AutoResolved = 4,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeRecord {
+    pub commission_id: Bytes,
+    pub opened_ledger: u32,
+    pub auto_resolve_ledger: u32,
+    pub status: DisputeStatus,
+    pub resolution_note: Option<String>,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    EscrowContract,
+    ConfigContract,
+    Dispute(Bytes),
+    AutoResolveLedgers,
+}


### PR DESCRIPTION
## Summary

Creates a new DisputeArbiter Soroban smart contract that manages dispute resolution for commission escrows.

### Changes
- **contracts/dispute_arbiter/** - New contract with:
  - initialize(admin, escrow_contract, config_contract, auto_resolve_ledgers) - one-time setup
  - open_dispute(commission_id, initiator) - creates an open dispute record
  - 
esolve_for_client(commission_id, note) - admin resolves in favor of client (triggers refund)
  - 
esolve_for_artist(commission_id, note) - admin resolves in favor of artist (triggers release)
  - get_dispute(commission_id) - reads dispute record
- 	ypes.rs - DisputeRecord, DisputeStatus enum, DataKey storage keys
- errors.rs - DisputeError enum with display impl and suggestion symbols
- 	est.rs - Unit tests for initialize, open_dispute, resolve_for_client, resolve_for_artist, get_dispute, and error codes
- Root Cargo.toml updated to include contracts/dispute_arbiter in workspace members

Closes #465
Closes #466
Closes #467
Closes #468